### PR TITLE
`makemigrations` check  during `lint` task

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,7 +29,7 @@ jobs:
         uses: ./.github/actions/build
 
       - name: lint
-        run: make lint -e RUN_MAKEMIGRATIONS=0
+        run: make lint -e RUN_MAKEMIGRATIONS=1
 
   test:
     needs: lint

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,7 +29,7 @@ jobs:
         uses: ./.github/actions/build
 
       - name: lint
-        run: make lint -e RUN_MAKEMIGRATIONS=1
+        run: make lint
 
   test:
     needs: lint

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,4 @@
 manage = poetry run python src/manage.py
-RUN_MAKEMIGRATIONS := 1
 PORT := 7070
 
 server:
@@ -31,9 +30,7 @@ fmt:
 	poetry run toml-sort pyproject.toml
 
 lint:
-ifeq ($(RUN_MAKEMIGRATIONS), 1)
 	$(manage) makemigrations --check --no-input --dry-run
-endif
 	poetry run ruff format --check src tests
 	poetry run ruff check src tests
 	poetry run toml-sort pyproject.toml --check

--- a/src/apps/books/models/book.py
+++ b/src/apps/books/models/book.py
@@ -232,7 +232,7 @@ class Order(TimestampedModel):
     status = models.CharField(
         choices=OrderStatus,
         max_length=2,
-        default=OrderStatus.PROCESSED,
+        default=OrderStatus.UNPROCESSED,
     )
     last_modified_by = models.ForeignKey(
         "users.User",

--- a/src/apps/books/models/book.py
+++ b/src/apps/books/models/book.py
@@ -232,7 +232,7 @@ class Order(TimestampedModel):
     status = models.CharField(
         choices=OrderStatus,
         max_length=2,
-        default=OrderStatus.UNPROCESSED,
+        default=OrderStatus.PROCESSED,
     )
     last_modified_by = models.ForeignKey(
         "users.User",


### PR DESCRIPTION
`makemigrations` check  during `lint` task

it's ok that it prints a DB warning
`connection to server at "localhost" (127.0.0.1), port 5432 failed: Connection refused`

It will still report the potential migration and exit early if that's the case
```
Migrations for 'books':
  src/apps/books/migrations/0010_alter_historicalorder_status_alter_order_status.py
    - Alter field status on historicalorder
    - Alter field status on order
make: *** [Makefile:35: lint] Error 1
Error: Process completed with exit code 2.

```