### PR TITLE
assume poetry installed on render

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -59,7 +59,7 @@ jobs:
         run: make test
 
   deploy:
-    if: github.ref == 'refs/heads/main' && github.repository_owner == 'peacefulseeker'
+    # if: github.ref == 'refs/heads/main' && github.repository_owner == 'peacefulseeker'
     needs: [lint, test]
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -59,7 +59,7 @@ jobs:
         run: make test
 
   deploy:
-    # if: github.ref == 'refs/heads/main' && github.repository_owner == 'peacefulseeker'
+    if: github.ref == 'refs/heads/main' && github.repository_owner == 'peacefulseeker'
     needs: [lint, test]
     runs-on: ubuntu-latest
     steps:

--- a/scripts/build-backend.sh
+++ b/scripts/build-backend.sh
@@ -1,6 +1,3 @@
-pip install --upgrade pip
-pip install poetry==1.8.3
-
 poetry install
 
 # Convert static asset files


### PR DESCRIPTION
Turned out Render will install poetry as a package manager depending on `POETRY_VERSION` env var
or the default one for the Python web service container out of the box
https://docs.render.com/poetry-version
same for specifying Python version 
https://docs.render.com/python-version

Logs from deployment job.
```
==> Using Python version 3.11.0 via environment variable PYTHON_VERSION
==> Docs on specifying a Python version: https://render.com/docs/python-version
==> Using Poetry version 1.8.3 via environment variable POETRY_VERSION
==> Docs on specifying a Poetry version: https://render.com/docs/poetry-version
==> Installing Poetry version 1.8.3
```