### PR TITLE
[try] deploy celery services via render.yaml file

### DIFF
--- a/.env.docker.sample
+++ b/.env.docker.sample
@@ -1,0 +1,8 @@
+PGUSER=postgres # also used for pg_isready check
+POSTGRES_PASSWORD=postgres
+PGPORT=5433
+DATABASE_URL=postgres://postgres:postgres@db:5433/web_libraryms # db is a docker compose service name
+
+CELERY_BROKER_URL=redis://redis:6379/0
+CELERY_ALWAYS_EAGER=false
+TIME_ZONE=Europe/Riga

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ __pycache__
 .coverage
 .DS_Store
 .env*
+!.env.docker.sample
 
 db/dump.json
 

--- a/compose/production/start_celery_beat
+++ b/compose/production/start_celery_beat
@@ -1,0 +1,7 @@
+#! /bin/sh
+set -o errexit
+set -o nounset
+
+
+rm -f /tmp/celerybeat.pid
+celery --app core --workdir src beat --loglevel=info --pidfile=/tmp/celerybeat.pid

--- a/compose/production/start_celery_flower
+++ b/compose/production/start_celery_flower
@@ -1,0 +1,5 @@
+#! /bin/sh
+set -o errexit
+set -o nounset
+
+celery --app core --workdir src --broker=${CELERY_BROKER_URL} flower

--- a/compose/production/start_celery_worker
+++ b/compose/production/start_celery_worker
@@ -1,0 +1,3 @@
+#! /bin/sh
+
+celery --app core --workdir src worker --loglevel=info

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,50 @@
+services:
+  - type: worker
+    name: celery_worker
+    region: frankfurt
+    runtime: python
+    buildCommand: "poetry install"
+    startCommand: "./compose/production/start_celery_worker"
+    autoDeploy: false
+    envVars:
+      - key: CELERY_BROKER_URL
+        fromService:
+          name: celery-redis
+          type: redis
+          property: connectionString
+
+  - type: web
+    name: celery_beat
+    region: frankfurt
+    runtime: python
+    buildCommand: "poetry install"
+    startCommand: "./compose/production/start_celery_beat"
+    autoDeploy: false
+    envVars:
+      - key: CELERY_BROKER_URL
+        fromService:
+          name: celery-redis
+          type: redis
+          property: connectionString
+
+  - type: web
+    name: celery_flower
+    region: frankfurt
+    plan: free
+    runtime: python
+    buildCommand: "poetry install"
+    startCommand: "./compose/production/start_celery_flower"
+    autoDeploy: false
+    envVars:
+      - key: CELERY_BROKER_URL
+        fromService:
+          type: redis
+          name: celery-redis
+          property: connectionString
+
+  - type: redis
+    name: celery-redis
+    region: frankfurt
+    plan: free # we choose a plan with persistence to ensure tasks are not lost upon restart
+    # maxmemoryPolicy: noeviction # recommended policy for queues
+    ipAllowList: [] # only allow internal connections

--- a/src/core/celery.py
+++ b/src/core/celery.py
@@ -22,7 +22,7 @@ app = Celery(
         },
         "ping_production_website": {
             "task": "core.tasks.ping_production_website",
-            "schedule": crontab(minute="*/5"),
+            "schedule": crontab(minute="*/10"),
         },
     },
 )


### PR DESCRIPTION
high chances that will fail because of
no free tier for workers, but let's try

Extras
- add `.env.docker.sample` 
- ping website every 10 minutes(every 15 minutes prod worker asleeps)