### PR TITLE
Reference reservation ID + few admin tweaks

### DIFF
--- a/src/core/tasks.py
+++ b/src/core/tasks.py
@@ -64,6 +64,7 @@ def send_reservation_confirmed_email(order_id: int):
     body = f"""
         Hi {order.member.username}!<br />
         "{order.book.title}" book is ready to be picked up. <br />
+        Your Reservation ID: {order.reservation.pk} <br />
         Check all your reservations <a href='{reservations_url}'>here</a>
     """
 

--- a/src/core/tasks.py
+++ b/src/core/tasks.py
@@ -65,7 +65,7 @@ def send_reservation_confirmed_email(order_id: int):
         Hi {order.member.username}!<br />
         "{order.book.title}" book is ready to be picked up. <br />
         Your Reservation ID: {order.reservation.pk} <br />
-        Check all your reservations <a href='{reservations_url}'>here</a>
+        Check all your reservations <a href='{reservations_url}' target='_blank'>here</a>
     """
 
     mailer = Mailer(

--- a/src/core/utils/admin.py
+++ b/src/core/utils/admin.py
@@ -1,4 +1,5 @@
 from django.contrib import admin
+from django.http import HttpRequest
 from simple_history.admin import SimpleHistoryAdmin
 
 
@@ -27,3 +28,17 @@ class StackedInline(AppAdminMixin, admin.StackedInline):
 
 class TabularInline(AppAdminMixin, admin.TabularInline):
     pass
+
+
+class ReadonlyTabularInline(TabularInline):
+    extra = 0
+    show_change_link = True
+
+    def has_change_permission(self, request, obj=None):
+        return False
+
+    def has_delete_permission(self, request, obj=None):
+        return False
+
+    def has_add_permission(self, request: HttpRequest, obj=None) -> bool:
+        return False

--- a/tests/core/tasks/test_send_reservation_confirmed_email.py
+++ b/tests/core/tasks/test_send_reservation_confirmed_email.py
@@ -26,6 +26,7 @@ def test_send_reservation_confirmed_email_success(mock_mailer, book_order):
     assert mailer_kwargs["subject"] == "Book is ready to be picked up"
     assert f"Hi {book_order.member.username}!" in mailer_kwargs["body"]
     assert f"{book_order.book.title}" in mailer_kwargs["body"]
+    assert f"Your Reservation ID: {book_order.reservation.id}" in mailer_kwargs["body"]
     assert "https://example.com/account/reservations/" in mailer_kwargs["body"]
 
 


### PR DESCRIPTION
- References reservation ID in a confirmation email to a member
- Readonly inlines for reservation/order/publisher/author 
- `is_booked_by_member` will tell whether the book is reserved or issued to the currently authenticated user/member
- closed "leave historical book reference for reservation". Now order inline will be tied to each reservation, and each order upon creation must have a book, which will tell the historical reservation book.

Frontend part: https://github.com/peacefulseeker/django-libraryms-frontend/commit/b8ce1b2554247925b1822f0e07d607e4ad46f470