### PR TITLE
Member registration request view

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,7 +69,9 @@ env = [
     "CELERY_ALWAYS_EAGER = 1",
     "CI = 1",
     "DEFAULT_FILE_STORAGE = django.core.files.storage.memory.InMemoryStorage",
+    "DISABLE_THROTTLING = 1",
     "PRODUCTION_URL = https://example.com",
+    "THROTTLING_ANON_RATE = 3/minute",
 ]
 markers = [
     "skip_create_books: test_book_list_view.py",

--- a/src/apps/users/admin.py
+++ b/src/apps/users/admin.py
@@ -1,38 +1,44 @@
 from django.contrib import admin
 from django.contrib.auth.admin import UserAdmin as BaseUserAdmin
-from django.http import HttpRequest
 from django.utils.translation import gettext_lazy as _
 
 from apps.users.models import Librarian, Member, User
 
 
-@admin.register(Librarian, Member)
 class PersonAdmin(BaseUserAdmin):
     show_full_result_count = False
-
-    fieldsets = (
-        (None, {"fields": ("username", "password")}),
-        (_("Personal info"), {"fields": ("first_name", "last_name", "email")}),
-        (_("Permissions"), {"fields": ("groups",)}),
-    )
     filter_horizontal = ("groups",)
-    list_display = ("username", "email", "is_staff", "is_active")
+    list_display = ("username", "email", "is_active")
 
     ordering = ("-date_joined",)
 
-    def get_fieldsets(self, request: HttpRequest, obj: Member | Librarian | None = ...):
-        fieldsets = super().get_fieldsets(request, obj)
-        if isinstance(obj, Member):
-            fieldsets += ((_("Registration"), {"fields": ("registration_code",)}),)
-        return fieldsets
 
-    def get_readonly_fields(self, request: HttpRequest, obj: Member | Librarian | None = ...):
-        if isinstance(obj, Member):
-            return ("registration_code",)
-        return ()
+@admin.register(Member)
+class MemberAdmin(PersonAdmin):
+    fieldsets = (
+        (None, {"fields": ("username", "password")}),
+        (
+            _("Registration"),
+            {
+                "description": "Code that member will receive upon registration request",
+                "fields": ("registration_code",),
+            },
+        ),
+        (_("Personal info"), {"fields": ("first_name", "last_name", "email")}),
+        (_("Permissions"), {"fields": ("is_active", "groups")}),
+    )
+    list_display = ("username", "email", "first_name", "last_name", "is_active")
+    readonly_fields = ("registration_code",)
 
-    def registration_code(self, obj: Member):
-        return obj.registration_code
+
+@admin.register(Librarian)
+class LibrarianAdmin(PersonAdmin):
+    fieldsets = (
+        (None, {"fields": ("username", "password")}),
+        (_("Personal info"), {"fields": ("first_name", "last_name", "email")}),
+        (_("Permissions"), {"fields": ("is_active", "is_staff", "groups")}),
+    )
+    list_display = PersonAdmin.list_display + ("is_staff",)
 
 
 @admin.register(User)

--- a/src/apps/users/admin.py
+++ b/src/apps/users/admin.py
@@ -1,5 +1,6 @@
 from django.contrib import admin
 from django.contrib.auth.admin import UserAdmin as BaseUserAdmin
+from django.http import HttpRequest
 from django.utils.translation import gettext_lazy as _
 
 from apps.users.models import Librarian, Member, User
@@ -7,6 +8,8 @@ from apps.users.models import Librarian, Member, User
 
 @admin.register(Librarian, Member)
 class PersonAdmin(BaseUserAdmin):
+    show_full_result_count = False
+
     fieldsets = (
         (None, {"fields": ("username", "password")}),
         (_("Personal info"), {"fields": ("first_name", "last_name", "email")}),
@@ -15,9 +18,27 @@ class PersonAdmin(BaseUserAdmin):
     filter_horizontal = ("groups",)
     list_display = ("username", "email", "is_staff", "is_active")
 
+    ordering = ("-date_joined",)
+
+    def get_fieldsets(self, request: HttpRequest, obj: Member | Librarian | None = ...):
+        fieldsets = super().get_fieldsets(request, obj)
+        if isinstance(obj, Member):
+            fieldsets += ((_("Registration"), {"fields": ("registration_code",)}),)
+        return fieldsets
+
+    def get_readonly_fields(self, request: HttpRequest, obj: Member | Librarian | None = ...):
+        if isinstance(obj, Member):
+            return ("registration_code",)
+        return ()
+
+    def registration_code(self, obj: Member):
+        return obj.registration_code
+
 
 @admin.register(User)
 class UseraAdmin(BaseUserAdmin):
+    show_full_result_count = False
+
     search_fields = ["username", "email"]
 
     fieldsets = (
@@ -36,3 +57,5 @@ class UseraAdmin(BaseUserAdmin):
             },
         ),
     )
+
+    ordering = ("-date_joined",)

--- a/src/apps/users/admin.py
+++ b/src/apps/users/admin.py
@@ -9,7 +9,7 @@ class PersonAdmin(BaseUserAdmin):
     show_full_result_count = False
     filter_horizontal = ("groups",)
     list_display = ("username", "email", "is_active")
-
+    search_fields = ["username", "email", "first_name", "last_name"]
     ordering = ("-date_joined",)
 
 
@@ -42,11 +42,7 @@ class LibrarianAdmin(PersonAdmin):
 
 
 @admin.register(User)
-class UseraAdmin(BaseUserAdmin):
-    show_full_result_count = False
-
-    search_fields = ["username", "email"]
-
+class UseraAdmin(PersonAdmin):
     fieldsets = (
         (None, {"fields": ("username", "password")}),
         (_("Personal info"), {"fields": ("first_name", "last_name", "email")}),
@@ -64,4 +60,4 @@ class UseraAdmin(BaseUserAdmin):
         ),
     )
 
-    ordering = ("-date_joined",)
+    list_display = PersonAdmin.list_display + ("is_staff", "is_superuser")

--- a/src/apps/users/api/serializers.py
+++ b/src/apps/users/api/serializers.py
@@ -1,11 +1,14 @@
 from django.conf import settings
+from django.contrib.auth.password_validation import validate_password
+from django.utils.translation import gettext_lazy as _
 from rest_framework import serializers
 from rest_framework_simplejwt.exceptions import InvalidToken
 from rest_framework_simplejwt.serializers import TokenObtainPairSerializer, TokenRefreshSerializer
 from rest_framework_simplejwt.tokens import AccessToken
 
-from apps.users.models import User
+from apps.users.models import Member, User
 from apps.users.types import AuthAttrs
+from core.tasks import send_member_registration_request_received, send_registration_notification_to_member
 
 
 class UserSerializer(serializers.ModelSerializer):
@@ -75,3 +78,35 @@ class CookieTokenObtainSerializer(TokenObtainPairSerializer):
         User.USERNAME_FIELD = original_username_field
 
         return data
+
+
+class MemberRegistrationRequestSerializer(serializers.ModelSerializer):
+    PASSWORD_MISMATCH_ERROR = _("Password fields didn't match.")
+
+    password = serializers.CharField(write_only=True, validators=[validate_password])
+    password_confirm = serializers.CharField(write_only=True)
+
+    class Meta:
+        model = Member
+        fields = ("uuid", "username", "email", "first_name", "last_name", "password", "password_confirm")
+
+    def validate(self, attrs):
+        if attrs["password"] != attrs["password_confirm"]:
+            raise serializers.ValidationError({"password": self.PASSWORD_MISMATCH_ERROR})
+        return super().validate(attrs)
+
+    def to_representation(self, instance: Member):
+        return {"registration_code": instance.registration_code}
+
+    def create(self, validated_data):
+        member = Member.objects.create_user(
+            is_active=False,
+            username=validated_data["username"],
+            email=validated_data["email"],
+            first_name=validated_data.get("first_name", ""),
+            last_name=validated_data.get("last_name", ""),
+            password=validated_data["password"],
+        )
+        send_member_registration_request_received.delay(member.id)
+        send_registration_notification_to_member.delay(member.id)
+        return member

--- a/src/apps/users/api/views.py
+++ b/src/apps/users/api/views.py
@@ -1,10 +1,16 @@
 from django.conf import settings
+from rest_framework import generics
+from rest_framework.permissions import AllowAny
 from rest_framework.response import Response
 from rest_framework.status import HTTP_204_NO_CONTENT
-from rest_framework.throttling import AnonRateThrottle
 from rest_framework_simplejwt.views import TokenObtainPairView, TokenRefreshView, TokenViewBase
 
-from apps.users.api.serializers import CookieTokenObtainSerializer, CookieTokenRefreshSerializer
+from apps.users.api.serializers import (
+    CookieTokenObtainSerializer,
+    CookieTokenRefreshSerializer,
+    MemberRegistrationRequestSerializer,
+)
+from core.throttling import AnonRateThrottle
 
 
 class CookieTokenMixin(TokenViewBase):
@@ -38,4 +44,10 @@ class CookieTokenObtainPairView(CookieTokenMixin, TokenObtainPairView):
 
 class CookieTokenRefreshView(CookieTokenMixin, TokenRefreshView):
     serializer_class = CookieTokenRefreshSerializer
+    throttle_classes = [AnonRateThrottle]
+
+
+class MemberRegistrationRequestView(generics.CreateAPIView):
+    permission_classes = [AllowAny]
+    serializer_class = MemberRegistrationRequestSerializer
     throttle_classes = [AnonRateThrottle]

--- a/src/apps/users/models.py
+++ b/src/apps/users/models.py
@@ -40,6 +40,15 @@ class Member(User):
 
     objects = UserRoleManager("is_member")
 
+    @property
+    def registration_code(self):
+        """
+        Code that will be sent to member upon registration request.
+        For simplicity, leveraging existing uuid field,
+        which can become essential part of public member profile later on.
+        """
+        return str(self.uuid.int)[:6]
+
 
 class Librarian(User):
     class Meta:

--- a/src/apps/users/models.py
+++ b/src/apps/users/models.py
@@ -1,5 +1,6 @@
 import uuid
 
+from django.contrib import admin
 from django.contrib.auth.models import AbstractUser, UserManager
 from django.db import models
 from django.utils.translation import gettext_lazy as _
@@ -41,6 +42,10 @@ class Member(User):
     objects = UserRoleManager("is_member")
 
     @property
+    @admin.display(
+        # description="Code that member will receive upon registration request",
+        boolean=False,
+    )
     def registration_code(self):
         """
         Code that will be sent to member upon registration request.

--- a/src/apps/users/urls/auth.py
+++ b/src/apps/users/urls/auth.py
@@ -1,8 +1,9 @@
 from django.urls import path
 
-from apps.users.api.views import CookieTokenObtainPairView, CookieTokenRefreshView
+from apps.users.api.views import CookieTokenObtainPairView, CookieTokenRefreshView, MemberRegistrationRequestView
 
 urlpatterns = [
     path("token/", CookieTokenObtainPairView.as_view(), name="token_obtain_pair"),
     path("token/refresh/", CookieTokenRefreshView.as_view(), name="token_refresh"),
+    path("register/", MemberRegistrationRequestView.as_view(), name="member_registration_request"),
 ]

--- a/src/core/conf/api.py
+++ b/src/core/conf/api.py
@@ -2,6 +2,9 @@ from datetime import timedelta
 
 from core.conf.environ import env
 
+DISABLE_THROTTLING = env.bool("DISABLE_THROTTLING", default=False)
+THROTTLING_ANON_RATE = env.str("THROTTLING_ANON_RATE", default="15/minute")
+
 REST_FRAMEWORK = {
     "SEARCH_PARAM": "q",
     "DEFAULT_FILTER_BACKENDS": [
@@ -14,7 +17,7 @@ REST_FRAMEWORK = {
     ],
     "EXCEPTION_HANDLER": "core.api.exceptions.drf_exception_handler",
     "DEFAULT_THROTTLE_RATES": {
-        "anon": "15/minute",
+        "anon": THROTTLING_ANON_RATE,
     },
 }
 

--- a/src/core/tasks.py
+++ b/src/core/tasks.py
@@ -83,7 +83,7 @@ def send_reservation_confirmed_email(order_id: int):
 
 @shared_task(name="core/send_member_registration_request_received")
 def send_member_registration_request_received(member_id: int):
-    member_admin_path = reverse("admin:users_user_change", kwargs={"object_id": member_id})
+    member_admin_path = reverse("admin:users_member_change", kwargs={"object_id": member_id})
     member_admin_url = urljoin(env("PRODUCTION_URL"), member_admin_path)
 
     body = f"""

--- a/src/core/throttling.py
+++ b/src/core/throttling.py
@@ -1,0 +1,15 @@
+from django.conf import settings
+from rest_framework.throttling import AnonRateThrottle as AnonRateThrottleNative
+from rest_framework.throttling import BaseThrottle
+
+
+class ThrottlingMixin(BaseThrottle):
+    def allow_request(self, request, view):
+        if settings.DISABLE_THROTTLING:
+            return True
+
+        return super().allow_request(request, view)
+
+
+class AnonRateThrottle(ThrottlingMixin, AnonRateThrottleNative):
+    pass

--- a/src/core/urls/__init__.py
+++ b/src/core/urls/__init__.py
@@ -18,7 +18,7 @@ if settings.DEBUG:
 
 urlpatterns += [
     path("", VueAppView.as_view(), name="app_home"),
-    re_path("^(login|books|account)", VueAppView.as_view(), name="app_routes"),
+    re_path("^(login|books|account|register)", VueAppView.as_view(), name="app_routes"),
 ]
 
 handler404 = "core.views.handler404"

--- a/src/core/utils/mailer.py
+++ b/src/core/utils/mailer.py
@@ -9,18 +9,24 @@ class Mailer:
         body,
         from_email=settings.AWS_SES_FROM_EMAIL,
         to=(settings.AWS_SES_FROM_EMAIL,),  # list or tuple
-        reply_to=("noreply@libms.dev",),  # list or tuple
+        reply_to=("noreply@django-libraryms.fly.dev",),  # list or tuple
         headers={},
     ):
         self.email = EmailMessage(
             subject=subject,
-            body=body,
+            body=self.compact_body(body),
             from_email=from_email,
             to=to,
             reply_to=reply_to,
             headers=headers,
         )
         self.email.content_subtype = "html"
+
+    @staticmethod
+    def compact_body(body) -> str:
+        "Strips whitespaces before/after and within each body line"
+
+        return "".join([line.strip() for line in body.split("\n")])
 
     def send(self) -> int:
         """

--- a/tests/apps/users/test_member_registration_view.py
+++ b/tests/apps/users/test_member_registration_view.py
@@ -1,0 +1,98 @@
+import pytest
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.response import Response
+
+from apps.users.api.serializers import MemberRegistrationRequestSerializer
+from apps.users.models import Member
+
+
+@pytest.mark.django_db
+class TestMemberRegistrationRequestView:
+    url = reverse("member_registration_request")
+
+    @pytest.fixture(autouse=True)
+    def mock_send_member_registration_request_received(self, mocker):
+        return mocker.patch("src.apps.users.api.serializers.send_member_registration_request_received")
+
+    @pytest.fixture(autouse=True)
+    def mock_send_registration_notification_to_member(self, mocker):
+        return mocker.patch("src.apps.users.api.serializers.send_registration_notification_to_member")
+
+    @pytest.fixture
+    def valid_payload(self):
+        return {
+            "username": "newmember",
+            "email": "newmember@example.com",
+            "password": "securepassword123",
+            "password_confirm": "securepassword123",
+            "first_name": "New",
+            "last_name": "Member",
+        }
+
+    @pytest.fixture
+    def _register_member(self, client, valid_payload) -> Response:
+        return client.post(self.url, valid_payload)
+
+    def test_success_registration_code_returned(self, client, valid_payload):
+        response = client.post(self.url, valid_payload)
+
+        assert response.status_code == status.HTTP_201_CREATED
+        assert "registration_code" in response.data
+
+    def test_success_registration_member_props(self, client, valid_payload):
+        response = client.post(self.url, valid_payload)
+
+        assert response.status_code == status.HTTP_201_CREATED
+
+        member = Member.objects.get(email=valid_payload["email"])
+        assert not member.is_active
+        assert member.username == valid_payload["username"]
+        assert member.check_password(valid_payload["password"])
+        assert member.first_name == valid_payload["first_name"]
+        assert member.last_name == valid_payload["last_name"]
+        assert member.email == valid_payload["email"]
+
+    def test_success_first_name_last_name_optional(self, client, valid_payload):
+        del valid_payload["first_name"]
+        del valid_payload["last_name"]
+
+        client.post(self.url, valid_payload)
+
+        member = Member.objects.get(email=valid_payload["email"])
+
+        assert member.first_name == ""
+        assert member.last_name == ""
+
+    def test_unique_username_and_email_validation_fails(self, _register_member, client, valid_payload):
+        response = client.post(self.url, valid_payload)
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert str(response.data["username"][0]) == Member.username.field.error_messages["unique"]
+        assert str(response.data["email"][0]) == Member.email.field.error_messages["unique"]
+
+    def test_unique_username_and_email_validation_succeeds(self, _register_member, client, valid_payload):
+        member_created_response: Response = _register_member
+
+        valid_payload["username"] = "anothermember"
+        valid_payload["email"] = "anothermember@example.com"
+
+        response: Response = client.post(self.url, valid_payload)
+
+        assert response.status_code == status.HTTP_201_CREATED
+        assert response.data["registration_code"] != member_created_response.data["registration_code"]
+
+    def test_password_confirmation_mismatch(self, client, valid_payload):
+        valid_payload["password_confirm"] = "anotherpassword"
+
+        response = client.post(self.url, valid_payload)
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert str(response.data["password"][0]) == MemberRegistrationRequestSerializer.PASSWORD_MISMATCH_ERROR
+
+    def test_notification_emails_sent_to_admin_and_member(
+        self, _register_member, mock_send_member_registration_request_received, mock_send_registration_notification_to_member, valid_payload
+    ):
+        member = Member.objects.get(email=valid_payload["email"])
+        assert mock_send_member_registration_request_received.delay.called_once_with(member.id)
+        assert mock_send_registration_notification_to_member.delay.called_once_with(member.id)

--- a/tests/apps/users/test_send_member_registration_request_received.py
+++ b/tests/apps/users/test_send_member_registration_request_received.py
@@ -1,0 +1,18 @@
+import pytest
+
+from core.tasks import send_member_registration_request_received
+
+pytestmark = pytest.mark.django_db
+
+
+def test_success(mock_mailer):
+    member_id = 1
+
+    result = send_member_registration_request_received.delay(member_id).get()
+
+    assert result["sent"]
+    call_kwargs = mock_mailer.call_args.kwargs
+    assert call_kwargs["subject"] == "Registration request received"
+    assert "Hi admin!" in call_kwargs["body"]
+    assert "New member registration request received" in call_kwargs["body"]
+    assert "https://example.com/admin/users/member/1/change/" in call_kwargs["body"]

--- a/tests/apps/users/test_send_registration_notification_to_member.py
+++ b/tests/apps/users/test_send_registration_notification_to_member.py
@@ -1,0 +1,37 @@
+import pytest
+from mixer.backend.django import mixer
+
+from apps.users.models import Member
+from core.tasks import send_registration_notification_to_member
+
+pytestmark = pytest.mark.django_db
+
+
+def test_send_member_does_not_exist():
+    member_id = 1
+
+    result = send_registration_notification_to_member.delay(member_id).get()
+
+    assert result["error"] == f"Member with id {member_id} does not exist"
+
+
+def test_send_success_with_first_name_in_greeting(mock_mailer):
+    member: Member = mixer.blend(Member)
+
+    result = send_registration_notification_to_member.delay(member.id).get()
+
+    assert result["sent"]
+    call_kwargs = mock_mailer.call_args.kwargs
+    assert call_kwargs["subject"] == "Thanks! Your registration request received"
+    assert f"Hi {member.first_name}!" in call_kwargs["body"]
+    assert f"Your registration code: {member.registration_code}." in call_kwargs["body"]
+    assert "Please arrive to library to complete registration" in call_kwargs["body"]
+    assert "Don't forget to bring your ID card." in call_kwargs["body"]
+
+
+def test_send_success_with_username_in_greeting(mock_mailer):
+    member: Member = mixer.blend(Member, first_name="")
+
+    send_registration_notification_to_member.delay(member.id).get()
+
+    assert f"Hi {member.username}!" in mock_mailer.call_args.kwargs["body"]

--- a/tests/apps/users/test_user.py
+++ b/tests/apps/users/test_user.py
@@ -29,3 +29,9 @@ def test_manager_objects_expected_to_return_group_members_only():
     assert User.objects.count() == 3
     assert Librarian.objects.count() == 1
     assert Member.objects.count() == 1
+
+
+def test_member_registration_code():
+    member: Member = mixer.blend(Member)
+
+    assert str(member.uuid.int).startswith(member.registration_code)

--- a/tests/core/api/test_throttling.py
+++ b/tests/core/api/test_throttling.py
@@ -1,0 +1,32 @@
+import pytest
+from django.urls import reverse
+from rest_framework import status
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture(autouse=True)
+def _enable_throttling(settings):
+    settings.DISABLE_THROTTLING = False
+
+
+class TestThrottling:
+    url = reverse("member_registration_request")
+    valid_payload = {
+        "username": "john.doe",
+        "email": "john.doe@example.com",
+        "password": "secret_password123",
+        "password_confirm": "secret_password123",
+    }
+
+    def test_throtted_response(self, client, settings):
+        throttle_limit = settings.THROTTLING_ANON_RATE.split("/")[0]
+
+        for num in range(int(throttle_limit)):
+            self.valid_payload["username"] += str(num)
+            self.valid_payload["email"] = str(num) + self.valid_payload["email"]
+            response = client.post(self.url, self.valid_payload)
+            assert response.status_code == status.HTTP_201_CREATED
+
+        response = client.post(self.url, self.valid_payload)
+        assert response.status_code == status.HTTP_429_TOO_MANY_REQUESTS

--- a/tests/core/tasks/test_ping_production_website.py
+++ b/tests/core/tasks/test_ping_production_website.py
@@ -1,5 +1,6 @@
 import pytest
 import requests
+from rest_framework import status
 
 from core.tasks import ping_production_website
 
@@ -12,14 +13,14 @@ def mock_get(mocker):
 def test_ping_production_website_success(mock_get):
     # Setup
     mock_response = mock_get.return_value
-    mock_response.status_code = 200
+    mock_response.status_code = status.HTTP_200_OK
     mock_response.elapsed.total_seconds.return_value = 0.5
 
     # Execute
     result = ping_production_website.delay().get()
 
     # Assert
-    assert result["status"] == 200
+    assert result["status"] == status.HTTP_200_OK
     assert result["response_time"] == 0.5
     assert result["url"] == "https://example.com"  # defined in pyproject pytest env
 

--- a/tests/core/tasks/test_send_order_created_email.py
+++ b/tests/core/tasks/test_send_order_created_email.py
@@ -9,5 +9,6 @@ def test_send_order_created_email(mock_mailer):
     assert result["sent"] == 1
     call_kwargs = mock_mailer.call_args.kwargs
     assert call_kwargs["subject"] == "Book order created"
-    assert "Hi admin! <br />Please process new book order" in call_kwargs["body"]
+    assert "Hi admin!" in call_kwargs["body"]
+    assert "Please process new book order" in call_kwargs["body"]
     assert "https://example.com/admin/books/order/1/change/" in call_kwargs["body"]

--- a/tests/core/tasks/test_send_reservation_confirmed_email.py
+++ b/tests/core/tasks/test_send_reservation_confirmed_email.py
@@ -24,10 +24,19 @@ def test_send_reservation_confirmed_email_success(mock_mailer, book_order):
 
     mailer_kwargs = mock_mailer.call_args.kwargs
     assert mailer_kwargs["subject"] == "Book is ready to be picked up"
-    assert f"Hi {book_order.member.username}!" in mailer_kwargs["body"]
+    assert f"Hi {book_order.member.first_name}!" in mailer_kwargs["body"]
     assert f"{book_order.book.title}" in mailer_kwargs["body"]
     assert f"Your Reservation ID: {book_order.reservation.id}" in mailer_kwargs["body"]
     assert "https://example.com/account/reservations/" in mailer_kwargs["body"]
+
+
+def test_send_reservation_confirmed_email_success_username_used_as_fallback(mock_mailer, book_order):
+    book_order.member.first_name = ""
+    book_order.member.save()
+
+    send_reservation_confirmed_email.delay(book_order.id).get()
+
+    assert f"Hi {book_order.member.username}!" in mock_mailer.call_args.kwargs["body"]
 
 
 def test_member_not_marked_as_notified_in_case_of_exception(mock_mailer, book_order):

--- a/tests/core/test_views.py
+++ b/tests/core/test_views.py
@@ -1,6 +1,7 @@
 from unittest.mock import patch
 
 import pytest
+from rest_framework import status
 from rest_framework.status import HTTP_200_OK
 
 
@@ -15,7 +16,7 @@ from rest_framework.status import HTTP_200_OK
 )
 def test_spa_route_views(client, path):
     response = client.get(path)
-    assert response.status_code == 200
+    assert response.status_code == status.HTTP_200_OK
     assert response.context.template_name == "vue-index.html"
     assert response.context["props"] == {}
 
@@ -35,7 +36,7 @@ def test_spa_view_props(client, mock_data, expected):
             mock_serializer.return_value.validate.return_value = mock_data
         response = client.get("/")
 
-        assert response.status_code == 200
+        assert response.status_code == status.HTTP_200_OK
         assert response.context["props"] == expected
 
 


### PR DESCRIPTION
Related frontend: https://github.com/peacefulseeker/django-libraryms-frontend/pull/4

Adds `/register` API endpoint for registering potential library members/readers.
Such registration presumingly simplifies initial member registration, allowing members
to leave his or her details such as full name and email only need to be confirmed by the librarian
physically at the library.

Upon successful registration form submission, the member will be inactive by default,
which means he/she won't be able to log in just yet. Approval will be needed from admin,
which will happen as soon as a member physically arrive in the library to confirm his identity.

![Screenshot 2024-08-21 at 14 03 00](https://github.com/user-attachments/assets/bf6e29e9-9186-4fe5-bba7-f50e83ec01b2)

### Extras
- configurable throttling(for disabling in tests in general) and 1 test case for actually triggering a throttled response back. 
- Shared `PersonaDmin` class for user/member/librarian admin models