### PR TITLE
User acount view update

### DIFF
--- a/src/apps/books/models/book.py
+++ b/src/apps/books/models/book.py
@@ -108,6 +108,7 @@ class BookQuerySet(models.QuerySet):
         return self.with_reservation_member().filter(reservation__member=member)
 
     def enqueued_by_member(self, member: Member) -> "BookQuerySet":
+        # TODO: prefetch member orders early
         return self.filter(orders__status=OrderStatus.IN_QUEUE, orders__member=member)
 
 

--- a/src/apps/users/api/views.py
+++ b/src/apps/users/api/views.py
@@ -1,6 +1,6 @@
 from django.conf import settings
 from rest_framework import generics
-from rest_framework.permissions import AllowAny
+from rest_framework.permissions import AllowAny, IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.status import HTTP_204_NO_CONTENT
 from rest_framework_simplejwt.views import TokenObtainPairView, TokenRefreshView, TokenViewBase
@@ -9,6 +9,7 @@ from apps.users.api.serializers import (
     CookieTokenObtainSerializer,
     CookieTokenRefreshSerializer,
     MemberRegistrationRequestSerializer,
+    UserProfileSerializer,
 )
 from core.throttling import AnonRateThrottle
 
@@ -51,3 +52,13 @@ class MemberRegistrationRequestView(generics.CreateAPIView):
     permission_classes = [AllowAny]
     serializer_class = MemberRegistrationRequestSerializer
     throttle_classes = [AnonRateThrottle]
+
+
+class MemberProfileView(generics.RetrieveUpdateAPIView):
+    permission_classes = [IsAuthenticated]
+    serializer_class = UserProfileSerializer
+
+    def retrieve(self, request, *args, **kwargs):
+        instance = request.user
+        serializer = self.get_serializer(instance)
+        return Response(serializer.data)

--- a/src/apps/users/urls/auth.py
+++ b/src/apps/users/urls/auth.py
@@ -1,9 +1,15 @@
 from django.urls import path
 
-from apps.users.api.views import CookieTokenObtainPairView, CookieTokenRefreshView, MemberRegistrationRequestView
+from apps.users.api.views import (
+    CookieTokenObtainPairView,
+    CookieTokenRefreshView,
+    MemberProfileView,
+    MemberRegistrationRequestView,
+)
 
 urlpatterns = [
     path("token/", CookieTokenObtainPairView.as_view(), name="token_obtain_pair"),
     path("token/refresh/", CookieTokenRefreshView.as_view(), name="token_refresh"),
     path("register/", MemberRegistrationRequestView.as_view(), name="member_registration_request"),
+    path("me/", MemberProfileView.as_view(), name="member_profile"),
 ]

--- a/tests/apps/users/test_cookie_token_refresh.py
+++ b/tests/apps/users/test_cookie_token_refresh.py
@@ -28,19 +28,14 @@ class TestCookieRefresh:
 
         assert response.status_code == HTTP_200_OK
 
-    def test_ensure_access_token_returned_with_user(self, as_member, member):
+    def test_ensure_access_token_returned_with_member_username(self, as_member, member):
         response: Response = as_member.post(self.url)
 
         assert response.status_code == HTTP_200_OK
 
         assert response.data["access"]
-        assert response.data["user"]
         assert response.data["user"] == {
-            "uuid": str(member.uuid),
             "username": member.username,
-            "email": member.email,
-            "first_name": member.first_name,
-            "last_name": member.last_name,
         }
 
     def test_deny_access_token_without_refresh_token_cookie(self, as_member):
@@ -58,3 +53,13 @@ class TestCookieRefresh:
 
         assert response.status_code == HTTP_401_UNAUTHORIZED
         assert str(response.data["detail"]) == "Token has wrong type"
+
+    def test_cookie_refresh_with_user_profile(self, as_member, member):
+        response: Response = as_member.post(self.url + "?fetch_user")
+
+        assert response.data["user"] == {
+            "username": member.username,
+            "email": member.email,
+            "first_name": member.first_name,
+            "last_name": member.last_name,
+        }

--- a/tests/apps/users/test_member_profile_view.py
+++ b/tests/apps/users/test_member_profile_view.py
@@ -1,0 +1,23 @@
+import pytest
+from django.urls import reverse
+from rest_framework import status
+
+
+@pytest.mark.django_db
+class TestMemberRegistrationRequestView:
+    url = reverse("member_profile")
+
+    def test_denied_for_unauthenticated_user(self, client):
+        response = client.get(self.url)
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+    def test_user_profile_returned(self, as_member, member):
+        response = as_member.get(self.url)
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data == {
+            "username": member.username,
+            "email": member.email,
+            "first_name": member.first_name,
+            "last_name": member.last_name,
+        }


### PR DESCRIPTION
- Access token endpoints will only send user username along with token from now on OR if explicit `fetch_user` param presents in request.
- Otherwise user data such email, first name should be requested from `/auth/me/` endpoint instead. Same endppint would potentially be used for updating user data -> e.g. setting avatar / update/change password from
member account view.