### PR TITLE
SQL query optimizations around book reservations/orders related queries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,9 @@ prod:
 shell:
 	$(manage) shell
 
+sqldebugshell:
+	$(manage) debugsqlshell
+
 static:
 	$(manage) collectstatic --no-input
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -79,17 +79,17 @@ wcwidth = ">=0.1.4"
 
 [[package]]
 name = "boto3"
-version = "1.35.0"
+version = "1.35.2"
 description = "The AWS SDK for Python"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "boto3-1.35.0-py3-none-any.whl", hash = "sha256:ada32dab854c46a877cf967b8a55ab1a7d356c3c87f1c8bd556d446ff03dfd95"},
-    {file = "boto3-1.35.0.tar.gz", hash = "sha256:bdc242e3ea81decc6ea551b04b2c122f088c29269d8e093b55862946aa0fcfc6"},
+    {file = "boto3-1.35.2-py3-none-any.whl", hash = "sha256:c2f0837a259002489e59d1c30008791e3b3bb59e30e48c64e1d2d270147a4549"},
+    {file = "boto3-1.35.2.tar.gz", hash = "sha256:cbf197ce28f04bc1ffa1db0aa26a1903d9bfa57a490f70537932e84367cdd15b"},
 ]
 
 [package.dependencies]
-botocore = ">=1.35.0,<1.36.0"
+botocore = ">=1.35.2,<1.36.0"
 jmespath = ">=0.7.1,<2.0.0"
 s3transfer = ">=0.10.0,<0.11.0"
 
@@ -98,13 +98,13 @@ crt = ["botocore[crt] (>=1.21.0,<2.0a0)"]
 
 [[package]]
 name = "botocore"
-version = "1.35.0"
+version = "1.35.2"
 description = "Low-level, data-driven core of boto 3."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "botocore-1.35.0-py3-none-any.whl", hash = "sha256:a3c96fe0b6afe7d00bad6ffbe73f2610953065fcdf0ed697eba4e1e5287cc84f"},
-    {file = "botocore-1.35.0.tar.gz", hash = "sha256:6ab2f5a5cbdaa639599e3478c65462c6d6a10173dc8b941bfc69b0c9eb548f45"},
+    {file = "botocore-1.35.2-py3-none-any.whl", hash = "sha256:92b168d8be79055bb25754aa34d699866d8aa66abc69f8ce99b0c191bd9c6e70"},
+    {file = "botocore-1.35.2.tar.gz", hash = "sha256:96c8eb6f0baed623a1b57ca9f24cb21d5508872cf0dfebb55527a85b6dbc76ba"},
 ]
 
 [package.dependencies]
@@ -711,6 +711,21 @@ files = [
 [package.dependencies]
 asgiref = ">=3.6"
 django = ">=3.2"
+
+[[package]]
+name = "django-debug-toolbar"
+version = "4.4.6"
+description = "A configurable set of panels that display various debug information about the current request/response."
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "django_debug_toolbar-4.4.6-py3-none-any.whl", hash = "sha256:3beb671c9ec44ffb817fad2780667f172bd1c067dbcabad6268ce39a81335f45"},
+    {file = "django_debug_toolbar-4.4.6.tar.gz", hash = "sha256:36e421cb908c2f0675e07f9f41e3d1d8618dc386392ec82d23bcfcd5d29c7044"},
+]
+
+[package.dependencies]
+django = ">=4.2.9"
+sqlparse = ">=0.2"
 
 [[package]]
 name = "django-environ"
@@ -1803,4 +1818,4 @@ brotli = ["brotli"]
 [metadata]
 lock-version = "2.0"
 python-versions = "~3.11"
-content-hash = "63cd321910fa37aead76297fc5a2de23a7dcf6af08e1c2fae10034d283e7a318"
+content-hash = "a407972f14ffd4df84638c7a84d8822ed7be44cd7f08a5eed0f59ac33efbad50"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ whitenoise = {extras = ["brotli"], version = "^6.7.0"}
 optional = true
 
 [tool.poetry.group.dev.dependencies]
+django-debug-toolbar = "^4.4.6"
 mixer = "^7.2.2"
 pytest-cov = "^5.0.0"
 pytest-deadfixtures = "^2.2.1"

--- a/src/apps/books/api/views.py
+++ b/src/apps/books/api/views.py
@@ -17,7 +17,7 @@ from apps.books.api.serializers import (
 from apps.books.const import OrderStatus
 from apps.books.models import Book
 from apps.books.models import Order as BookOrder
-from apps.books.models.book import Order, Reservation
+from apps.books.models.book import BookQuerySet, Order, Reservation
 from apps.users.models import Member
 from core.tasks import send_order_created_email
 
@@ -43,18 +43,23 @@ class BookListView(ViewSetMixin, generics.ListAPIView):
         if self.is_authenticated and self.query_params.get("reserved_by_me") is not None:
             return True
 
+    def show_enqueued_by_member(self):
+        if self.is_authenticated and self.query_params.get("enqueued_by_me") is not None:
+            return True
+
     def get_serializer_class(self):
-        if self.show_reserved_by_member():
+        if self.show_reserved_by_member() or self.show_enqueued_by_member():
             return BooksReservedByMemberSerializer
         return BookListSerializer
 
-    def get_queryset(self):
-        queryset = Book.objects.with_author().with_reservation()
+    def get_queryset(self) -> BookQuerySet:
+        queryset = Book.objects.with_author().with_reservation().with_amount_in_queue()
         if self.query_params.get("available") is not None:
             return queryset.available()
         elif self.show_reserved_by_member():
-            reserved_and_enqueued = queryset.reserved_by_member(self.request.user) | queryset.enqueued_by_member(self.request.user)
-            return reserved_and_enqueued.distinct()
+            return queryset.reserved_by_member(self.request.user)
+        elif self.show_enqueued_by_member():
+            return queryset.enqueued_by_member(self.request.user)
         return queryset
 
 
@@ -67,10 +72,10 @@ class BookDetailView(ViewSetMixin, generics.RetrieveAPIView):
         return BookSerializer
 
     def get_queryset(self):
-        queryset = Book.objects.with_author().with_publisher()
+        queryset = Book.objects.with_author().with_publisher().with_amount_in_queue().with_reservation()
 
         if self.is_authenticated:
-            return queryset.with_reservation_member()
+            return queryset.with_enqueued_by_member(self.request.user).with_member_total_reservations_amount(self.request.user)
 
         return queryset
 

--- a/src/core/conf/installed_apps.py
+++ b/src/core/conf/installed_apps.py
@@ -1,3 +1,5 @@
+from core.conf.environ import env
+
 # fmt: off
 INSTALLED_APPS = [
     "django.contrib.admin",
@@ -22,3 +24,7 @@ INSTALLED_APPS = [
     "core",
 ]
 # fmt: on
+if env("DEBUG"):
+    INSTALLED_APPS += [
+        "debug_toolbar",
+    ]

--- a/src/core/conf/middleware.py
+++ b/src/core/conf/middleware.py
@@ -16,6 +16,9 @@ if not env("DEBUG"):
     # https://whitenoise.readthedocs.io/en/stable/django.html#enable-whitenoise
     # should be placed directly after the Django SecurityMiddleware
     MIDDLEWARE.insert(1, "whitenoise.middleware.WhiteNoiseMiddleware")
+else:
+    MIDDLEWARE.insert(5, "debug_toolbar.middleware.DebugToolbarMiddleware")
+
 
 if env("DB_LOGGING_ENABLED", cast=bool, default=False):
     MIDDLEWARE.insert(2, "core.middleware.sql.SqlPrintingMiddleware")

--- a/tests/apps/books/test_book.py
+++ b/tests/apps/books/test_book.py
@@ -118,9 +118,11 @@ def test_processed_order_created_when_reservation_assigned():
 
 
 def test_book_available_by_default():
-    book = mixer.blend(Book)
-    assert book.reservation is None
+    book: Book = mixer.blend(Book)
+
     assert book.is_available
+    assert book.reservation_id is None
+    assert not book.is_booked
 
 
 def test_not_booked_by_default(book, member):
@@ -189,6 +191,8 @@ def test_book_is_reserved_aka_booked(book, member):
 
     assert book.is_reserved
     assert book.is_booked
+    assert book.reservation_id
+    assert not book.reservation_term
     assert book.is_booked_by_member(member)
 
 
@@ -199,6 +203,8 @@ def test_book_is_issued_aka_booked(book, member):
 
     assert book.is_issued
     assert book.is_booked
+    assert book.reservation_id
+    assert book.reservation_term
     assert book.is_booked_by_member(member)
 
 
@@ -208,3 +214,5 @@ def test_book_is_booked_by_another_member(book, another_member, member):
     assert book.is_booked
     assert not book.is_booked_by_member(member)
     assert book.is_booked_by_member(another_member)
+    assert book.reservation_id
+    assert not book.reservation_term

--- a/tests/apps/books/views/test_book_detail_view.py
+++ b/tests/apps/books/views/test_book_detail_view.py
@@ -114,7 +114,7 @@ def test_is_not_reserved_by_member(as_member, book):
     assert not response.data["is_reserved_by_member"]
 
 
-def test_is_queued_by_member(as_member, book, member):
+def test_is_enqueued_by_member(as_member, book, member):
     mixer.blend(Order, book=book, member=member, status=OrderStatus.IN_QUEUE)
     url = reverse("book-detail", kwargs={"pk": book.id})
 
@@ -123,7 +123,7 @@ def test_is_queued_by_member(as_member, book, member):
     assert response.data["is_enqueued_by_member"]
 
 
-def test_is_not_queued_by_member(as_member, book):
+def test_not_is_enqueued_by_member(as_member, book):
     url = reverse("book-detail", kwargs={"pk": book.id})
 
     response = as_member.get(url)

--- a/tests/apps/books/views/test_book_list_view.py
+++ b/tests/apps/books/views/test_book_list_view.py
@@ -167,7 +167,7 @@ class TestBooksReservedByMemberView:
 
         assert book.orders.count() == 2
 
-        response = authenticated_client(member).get(self.url, {"reserved_by_me": ""})
+        response = authenticated_client(member).get(self.url, {"enqueued_by_me": ""})
         assert len(response.data) == 1
         enqueued_book = response.data[0]
         assert enqueued_book["is_enqueued_by_member"]
@@ -187,13 +187,16 @@ class TestBooksReservedByMemberView:
 
         response = authenticated_client(member).get(self.url, {"reserved_by_me": ""})
 
-        assert len(response.data) == 2
+        assert len(response.data) == 1
         reserved_book = response.data[0]
         assert reserved_book["id"] == book_order.book.id
         assert reserved_book["reservation_id"] == book_order.reservation.id
         assert reserved_book["reservation_term"] == book_order.reservation.term
 
-        enqueued_book = response.data[1]
+        response = authenticated_client(member).get(self.url, {"enqueued_by_me": ""})
+
+        assert len(response.data) == 1
+        enqueued_book = response.data[0]
         assert enqueued_book["id"] == book.id
         assert enqueued_book["is_enqueued_by_member"]
         assert enqueued_book["amount_in_queue"] == 2


### PR DESCRIPTION
- added enqueued_by_member, tota_reservations, amount_in_queuee annotations for book list/detail views.
- split reserved and enqueued by member queries to be more explicit/transparent about expected output from API
- added a debug toolbar, for now, to check SQL queries executed in a shell

### Later
- at some point would need to introduce more sophisticated type hints. Annotated fields are not part of models themselves, e.g. 