### PR TITLE
Member password change API

### DIFF
--- a/src/apps/users/api/serializers.py
+++ b/src/apps/users/api/serializers.py
@@ -126,3 +126,9 @@ class MemberRegistrationRequestSerializer(serializers.ModelSerializer):
         send_member_registration_request_received.delay(member.id)
         send_registration_notification_to_member.delay(member.id)
         return member
+
+
+class MemberPasswordChangeSerializer(serializers.Serializer):
+    password_current = serializers.CharField(write_only=True, required=True)
+    password_new = serializers.CharField(write_only=True, required=True, validators=[validate_password])
+    password_new_confirm = serializers.CharField(write_only=True, required=True, validators=[validate_password])

--- a/src/apps/users/api/views.py
+++ b/src/apps/users/api/views.py
@@ -1,16 +1,19 @@
 from django.conf import settings
+from django.utils.translation import gettext_lazy as _
 from rest_framework import generics
 from rest_framework.permissions import AllowAny, IsAuthenticated
 from rest_framework.response import Response
-from rest_framework.status import HTTP_204_NO_CONTENT
+from rest_framework.status import HTTP_204_NO_CONTENT, HTTP_400_BAD_REQUEST
 from rest_framework_simplejwt.views import TokenObtainPairView, TokenRefreshView, TokenViewBase
 
 from apps.users.api.serializers import (
     CookieTokenObtainSerializer,
     CookieTokenRefreshSerializer,
+    MemberPasswordChangeSerializer,
     MemberRegistrationRequestSerializer,
     UserProfileSerializer,
 )
+from apps.users.models import Member
 from core.throttling import AnonRateThrottle
 
 
@@ -62,3 +65,36 @@ class MemberProfileView(generics.RetrieveUpdateAPIView):
         instance = request.user
         serializer = self.get_serializer(instance)
         return Response(serializer.data)
+
+
+class MemberPasswordChange(generics.UpdateAPIView):
+    permission_classes = [IsAuthenticated]
+    serializer_class = MemberPasswordChangeSerializer
+
+    def update(self, request, *args, **kwargs):
+        instance: Member = request.user
+
+        serializer = self.get_serializer(instance, data=request.data)
+        serializer.is_valid(raise_exception=True)
+
+        if not instance.check_password(serializer.validated_data["password_current"]):
+            return Response(
+                {"password_current": [_("Wrong password.")]},
+                status=HTTP_400_BAD_REQUEST,
+            )
+
+        if serializer.validated_data["password_new"] == serializer.validated_data["password_current"]:
+            return Response(
+                {"password_new": [_("New password must be different from current password.")]},
+                status=HTTP_400_BAD_REQUEST,
+            )
+
+        if serializer.validated_data["password_new"] != serializer.validated_data["password_new_confirm"]:
+            return Response(
+                {"password_new_confirm": [_("New password and confirmation did not match.")]},
+                status=HTTP_400_BAD_REQUEST,
+            )
+
+        instance.set_password(serializer.validated_data["password_new"])
+        instance.save()
+        return Response(status=HTTP_204_NO_CONTENT)

--- a/src/apps/users/urls/auth.py
+++ b/src/apps/users/urls/auth.py
@@ -3,6 +3,7 @@ from django.urls import path
 from apps.users.api.views import (
     CookieTokenObtainPairView,
     CookieTokenRefreshView,
+    MemberPasswordChange,
     MemberProfileView,
     MemberRegistrationRequestView,
 )
@@ -12,4 +13,5 @@ urlpatterns = [
     path("token/refresh/", CookieTokenRefreshView.as_view(), name="token_refresh"),
     path("register/", MemberRegistrationRequestView.as_view(), name="member_registration_request"),
     path("me/", MemberProfileView.as_view(), name="member_profile"),
+    path("password/change/", MemberPasswordChange.as_view(), name="member_password_change"),
 ]

--- a/tests/apps/users/test_cookie_token_obtain.py
+++ b/tests/apps/users/test_cookie_token_obtain.py
@@ -25,10 +25,12 @@ def serializer() -> CookieTokenObtainSerializer:
 
 
 class TestTokenFromUsernameOrEmail:
-    attrs = {
-        "username": "member",
-        "password": "member",
-    }
+    @pytest.fixture(autouse=True)
+    def setup_props(self, member):
+        self.attrs = {
+            "username": "member",
+            "password": member.raw_password,
+        }
 
     def test_validate_against_username(self, member, serializer):
         data = serializer.validate(self.attrs)
@@ -64,7 +66,7 @@ class TestTokenFromUsernameOrEmail:
             serializer.validate(attrs)
 
     def test_validate_against_email(self, member, serializer):
-        attrs = {"username": "member@member.com", "password": "member"}
+        attrs = {"username": "member@member.com", "password": member.raw_password}
 
         data = serializer.validate(attrs)
 
@@ -80,7 +82,7 @@ class TestTokenFromUsernameOrEmail:
         ],
     )
     def test_validate_against_email_wrong_email(self, email, serializer):
-        attrs = {**self.attrs, "email": email}
+        attrs = {**self.attrs, "username": email}
 
         with pytest.raises(rest_framework.exceptions.AuthenticationFailed):
             serializer.validate(attrs)
@@ -92,7 +94,7 @@ class TestTokenFromUsernameOrEmail:
             serializer.validate(attrs)
 
     def test_ensure_original_username_field_restored_on_any_kind_of_exception(self, mock_token_validate, member, serializer):
-        attrs = {"username": "member@member.com", "password": "member"}
+        attrs = {"username": "member@member.com", "password": member.raw_password}
         mock_token_validate.side_effect = Exception("any exception raised during validation")
 
         with pytest.raises(Exception):
@@ -102,11 +104,13 @@ class TestTokenFromUsernameOrEmail:
 
 
 class TestCookieTokenObtain:
-    url = reverse("token_obtain_pair")
-    data = {
-        "username": "member",
-        "password": "member",
-    }
+    @pytest.fixture(autouse=True)
+    def setup_props(self, member):
+        self.url = reverse("token_obtain_pair")
+        self.data = {
+            "username": "member",
+            "password": member.raw_password,
+        }
 
     def test_access_token_obtain_from_api_with_username_only(self, as_member, member):
         response: Response = as_member.post(self.url, data=self.data)

--- a/tests/apps/users/test_member_password_change_view.py
+++ b/tests/apps/users/test_member_password_change_view.py
@@ -1,0 +1,66 @@
+import pytest
+from django.urls import reverse
+from rest_framework import status
+
+
+@pytest.mark.django_db
+class TestMemberPasswordChange:
+    @pytest.fixture(autouse=True)
+    def setup_props(self, member):
+        self.url = reverse("member_password_change")
+        self.payload = {
+            "password_current": member.raw_password,
+            "password_new": "newpassword456",
+            "password_new_confirm": "newpassword456",
+        }
+
+    def test_unauthorized(self, client):
+        response = client.put(self.url, self.payload)
+
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+    def test_success(self, as_member, member):
+        response = as_member.put(self.url, self.payload)
+
+        member.refresh_from_db()
+        assert response.status_code == status.HTTP_204_NO_CONTENT
+        assert member.check_password(self.payload["password_new"])
+
+    def test_new_password_same_as_current(self, as_member, member):
+        self.payload["password_new"] = member.raw_password
+
+        response = as_member.put(self.url, self.payload)
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert response.data["password_new"][0] == "New password must be different from current password."
+
+    def test_too_short_password(self, as_member):
+        self.payload["password_new"] = "member"
+
+        response = as_member.put(self.url, self.payload)
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert response.data["password_new"][0] == "This password is too short. It must contain at least 8 characters."
+
+    def test_wrong_old_password(self, as_member):
+        self.payload["password_current"] = "wrongpassword"
+
+        response = as_member.put(self.url, self.payload)
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert response.data["password_current"][0] == "Wrong password."
+
+    def test_missing_required_fields(self, as_member):
+        self.payload = {"password_current": "member"}
+
+        response = as_member.put(self.url, self.payload)
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert "password_new" in response.data
+        assert "password_new_confirm" in response.data
+
+    def test_password_change_mismatch_confirm(self, as_member):
+        self.payload["password_new_confirm"] = "mismatch"
+
+        response = as_member.put(self.url, self.payload)
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert response.data["password_new_confirm"][0] == "New password and confirmation did not match."

--- a/tests/fixtures/users.py
+++ b/tests/fixtures/users.py
@@ -7,7 +7,8 @@ from apps.users.models import Member
 @pytest.fixture
 def member():
     member = mixer.blend(Member, username="member", email="member@member.com")
-    member.set_password("member")
+    member.raw_password = "member1234"  # for authentication related tests
+    member.set_password(member.raw_password)
     member.save()
     return member
 


### PR DESCRIPTION
- Adds `/api/v1/auth/password/change/` PUT/PATCH endpoint 
- in tests saves member password in `raw_password` for convenient reuse.

Related frontend: https://github.com/peacefulseeker/django-libraryms-frontend/pull/6