### PR TITLE
Few more SQL optimizations

### DIFF
--- a/src/apps/books/admin/admin.py
+++ b/src/apps/books/admin/admin.py
@@ -74,13 +74,10 @@ class PublisherAdmin(ModelAdmin, ImportExportModelAdmin):
 @admin.register(Reservation)
 class ReservationAdmin(ModelAdmin):
     readonly_fields = (
-        # "member",
         "created_at",
         "modified_at",
     )
-    autocomplete_fields = [
-        "member",
-    ]
+    autocomplete_fields = ("member",)
     search_fields = ("member",)
     list_display = (
         "id",

--- a/src/apps/books/admin/order.py
+++ b/src/apps/books/admin/order.py
@@ -11,31 +11,22 @@ from core.utils.admin import HistoricalModelAdmin
 
 @admin.register(Order)
 class OrderAdmin(HistoricalModelAdmin):
-    readonly_fields = ("last_modified_by", "reservation", "member", "book")
-    history_list_display = ("status",)
-    # Select2 search user-friendly
-    autocomplete_fields = [
-        "member",
+    readonly_fields = (
+        "last_modified_by",
         "reservation",
+        "member",
         "book",
-    ]
-
-    fieldsets = (
-        (
-            None,
-            {
-                "fields": (
-                    "member",
-                    "book",
-                    "status",
-                    "reservation",
-                    "change_reason",
-                    "last_modified_by",
-                )
-            },
-        ),
     )
-    list_select_related = ["book", "member"]
+    history_list_display = ("status",)
+    fields = (
+        "member",
+        "book",
+        "status",
+        "reservation",
+        "change_reason",
+        "last_modified_by",
+    )
+
     list_display = (
         "id",
         "status",
@@ -44,12 +35,15 @@ class OrderAdmin(HistoricalModelAdmin):
         "last_modified_by",
         "created_at",
     )
-
     list_display_links = (
         "id",
         "status",
         "book",
     )
+
+    def get_queryset(self, request: HttpRequest) -> QuerySet[Any]:
+        qs = super().get_queryset(request).select_related("reservation", "book", "member", "last_modified_by")
+        return qs
 
     def has_add_permission(self, request: HttpRequest) -> bool:  # pragma: no cover
         """

--- a/src/apps/books/api/views.py
+++ b/src/apps/books/api/views.py
@@ -1,3 +1,4 @@
+from django.db import transaction
 from django.db.models import QuerySet
 from django.shortcuts import get_object_or_404
 from django.utils.translation import gettext_lazy as _
@@ -125,7 +126,8 @@ class BookOrderView(APIView):
             order_status = OrderStatus.IN_QUEUE
             message = _("Book reservation request put in queue")
 
-        order = BookOrder.objects.create(book=book, member=member, status=order_status)
+        with transaction.atomic():
+            order = BookOrder.objects.create(book=book, member=member, status=order_status)
 
         return order, message
 

--- a/src/apps/books/models/book.py
+++ b/src/apps/books/models/book.py
@@ -84,7 +84,7 @@ class Reservation(TimestampedModel):
         return self.is_issued and self.overdue_days > 0
 
     def __str__(self):
-        return f"{self.member} - {self.get_status_display()}"
+        return f"{self.pk} - {self.member} - {self.get_status_display()}"
 
 
 class BookQuerySet(models.QuerySet):
@@ -336,4 +336,4 @@ class Order(TimestampedModel):
         send_reservation_confirmed_email.delay(self.id, self.reservation.id)
 
     def __str__(self):
-        return f"{self.member} - {self.book} - {self.status}"
+        return f"{self.pk} - {self.get_status_display()}"

--- a/src/core/conf/debug_toolbar.py
+++ b/src/core/conf/debug_toolbar.py
@@ -1,0 +1,26 @@
+INTERNAL_IPS = [
+    "127.0.0.1",
+]
+
+
+DEBUG_TOOLBAR_PANELS = [
+    "debug_toolbar.panels.sql.SQLPanel",
+    # "debug_toolbar.panels.timer.TimerPanel",
+    # "debug_toolbar.panels.settings.SettingsPanel",
+    # "debug_toolbar.panels.headers.HeadersPanel",
+    # "debug_toolbar.panels.request.RequestPanel",
+    # "debug_toolbar.panels.staticfiles.StaticFilesPanel",
+    # "debug_toolbar.panels.cache.CachePanel",
+    # "debug_toolbar.panels.signals.SignalsPanel",
+    # "debug_toolbar.panels.templates.TemplatesPanel",
+    # "debug_toolbar.panels.redirects.RedirectsPanel",
+    # "debug_toolbar.panels.profiling.ProfilingPanel",
+]
+
+DEBUG_TOOLBAR_PATHS = [
+    "/__debug__/",
+    "/admin/",
+]
+DEBUG_TOOLBAR_CONFIG = {
+    "SHOW_TOOLBAR_CALLBACK": lambda request: any(request.path.startswith(path) for path in DEBUG_TOOLBAR_PATHS),
+}

--- a/src/core/settings.py
+++ b/src/core/settings.py
@@ -17,6 +17,7 @@ include(
     "conf/security.py",
     "conf/i18n.py",
     "conf/installed_apps.py",
+    "conf/debug_toolbar.py",
     "conf/middleware.py",
     "conf/templates.py",
     "conf/static.py",

--- a/src/core/urls/__init__.py
+++ b/src/core/urls/__init__.py
@@ -1,3 +1,4 @@
+from debug_toolbar.toolbar import debug_toolbar_urls
 from django.conf import settings
 from django.conf.urls.static import static
 from django.contrib import admin
@@ -15,6 +16,7 @@ urlpatterns = [
 
 if settings.DEBUG:
     urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)  # pragma: no cover
+    urlpatterns += debug_toolbar_urls()
 
 urlpatterns += [
     path("", VueAppView.as_view(), name="app_home"),

--- a/tests/apps/books/test_order.py
+++ b/tests/apps/books/test_order.py
@@ -14,7 +14,8 @@ def mock_send_reservation_confirmed_email(mocker):
 
 def test_order_str_method():
     order = mixer.blend(Order)
-    expected_str = f"{order.member} - {order.book} - {order.status}"
+
+    expected_str = f"{order.pk} - {OrderStatus.UNPROCESSED.label}"
     assert str(order) == expected_str
 
 

--- a/tests/apps/books/test_reservation.py
+++ b/tests/apps/books/test_reservation.py
@@ -12,7 +12,8 @@ pytestmark = pytest.mark.django_db
 
 def test_reservation_str_method():
     reservation = mixer.blend(Reservation)
-    expected_str = f"{reservation.member} - {ReservationStatus.RESERVED.label}"
+
+    expected_str = f"{reservation.pk} - {reservation.member} - {ReservationStatus.RESERVED.label}"
     assert str(reservation) == expected_str
 
 
@@ -55,17 +56,13 @@ def test_reservation_unlinked_from_book_on_status_change(status):
     assert not hasattr(reservation, "book")
 
 
-def test_reservation_ordered_by_last_modified():
+def test_reservation_ordered_by_modified_at():
     reservation1 = mixer.blend(Reservation)
     reservation2 = mixer.blend(Reservation)
     reservation3 = mixer.blend(Reservation)
 
-    reservation2.status = ReservationStatus.RESERVED
     reservation2.save()
-
     reservation1.save()
-
-    reservation3.status = ReservationStatus.COMPLETED
     reservation3.save()
 
     reservations = Reservation.objects.all()
@@ -73,7 +70,7 @@ def test_reservation_ordered_by_last_modified():
     assert list(reservations) == [reservation3, reservation1, reservation2]
 
 
-def test_reservation_ordered_by_last_modified_with_nulls_last():
+def test_reservation_ordered_by_modified_at_with_nulls_last():
     reservation1 = mixer.blend(Reservation)
     reservation2 = mixer.blend(Reservation)
     reservation3 = mixer.blend(Reservation)


### PR DESCRIPTION
- Ensures atomicity for book order creation through API. (order creation + reservation creation + book update all or nothing)
- installs Django debug toolbar - for now SQL panel and only admin views. For API views still leveraging custom `SqlPrintingMiddleware`
- `list_select_related` only works for list views, but does not change opinions. Adding select_relaed in overridden `get_queryset` seems to cover both cases and it reduces the number of queries once the object is saved from admin.