### PR TITLE
Reservation term reminder

### DIFF
--- a/src/apps/books/admin/admin.py
+++ b/src/apps/books/admin/admin.py
@@ -88,6 +88,7 @@ class ReservationAdmin(ModelAdmin):
         "modified_at",
     )
 
+    list_filter = ("status",)
     list_select_related = ["member", "book"]
     list_display_links = (
         "id",

--- a/src/apps/books/admin/order.py
+++ b/src/apps/books/admin/order.py
@@ -27,6 +27,7 @@ class OrderAdmin(HistoricalModelAdmin):
         "last_modified_by",
     )
 
+    list_filter = ("status",)
     list_display = (
         "id",
         "status",

--- a/src/apps/tasks.py
+++ b/src/apps/tasks.py
@@ -1,0 +1,37 @@
+from urllib.parse import urljoin
+
+from celery import shared_task
+from django.utils import timezone
+
+from apps.books.const import ReservationStatus
+from apps.books.models import Reservation
+from core.conf.environ import env
+from core.utils.mailer import Mailer, Message
+
+
+@shared_task(name="books/reservation_term_reminder")
+def send_reservation_term_reminder(due_in_days=2):
+    now = timezone.now()
+    reservations: list[Reservation] = Reservation.objects.select_related("book", "member").filter(
+        term=now + timezone.timedelta(days=due_in_days), status=ReservationStatus.ISSUED
+    )
+    messages = []
+    reservations_url = urljoin(env("PRODUCTION_URL"), "account/reservations/")
+    for reservation in reservations:
+        member = reservation.member
+        body = f"""
+            Hi {member.first_name or member.username}!<br />
+            Your book '{reservation.book.title}' reservation is due on {reservation.term}.<br />
+            Please return it on time or extend it. <br />
+            Otherwise, you will be charged a fine. <br />
+            Check all your reservations <a href='{reservations_url}' target='_blank'>here</a>
+        """
+        messages.append(
+            Message(
+                subject=f"Reservation term is ending in {due_in_days} days",
+                body=body,
+            )
+        )
+
+    emails_sent = Mailer.send_mass_mail(messages, fail_silently=True)
+    return emails_sent

--- a/src/apps/tasks.py
+++ b/src/apps/tasks.py
@@ -20,7 +20,7 @@ def send_reservation_term_reminder(due_in_days=2):
     for reservation in reservations:
         member = reservation.member
         body = f"""
-            Hi {member.first_name or member.username}!<br />
+            Hi {member.name}!<br />
             Your book '{reservation.book.title}' reservation is due on {reservation.term}.<br />
             Please return it on time or extend it. <br />
             Otherwise, you will be charged a fine. <br />

--- a/src/apps/tasks.py
+++ b/src/apps/tasks.py
@@ -34,4 +34,4 @@ def send_reservation_term_reminder(due_in_days=2):
         )
 
     emails_sent = Mailer.send_mass_mail(messages, fail_silently=True)
-    return emails_sent
+    return {"sent": emails_sent}

--- a/src/apps/users/models.py
+++ b/src/apps/users/models.py
@@ -87,6 +87,10 @@ class Member(User):
         """
         return str(self.uuid.int)[:6]
 
+    @property
+    def name(self):
+        return self.first_name or self.username
+
 
 class Librarian(User):
     class Meta:

--- a/src/core/api/exceptions.py
+++ b/src/core/api/exceptions.py
@@ -7,6 +7,6 @@ def drf_exception_handler(exc, context):
     response = exception_handler(exc, context)
 
     if isinstance(exc, Throttled):
-        response.data["detail"] = _("Too Many Requests")
+        response.data["detail"] = _("Too Many Requests. Try again later.")
 
     return response

--- a/src/core/api/exceptions.py
+++ b/src/core/api/exceptions.py
@@ -7,6 +7,6 @@ def drf_exception_handler(exc, context):
     response = exception_handler(exc, context)
 
     if isinstance(exc, Throttled):
-        response.data["detail"] = _("Too Many Requests. Try again later.")
+        response.data["detail"] = _("Too Many Requests")
 
     return response

--- a/src/core/celery.py
+++ b/src/core/celery.py
@@ -27,5 +27,6 @@ def debug_task(self):
 celery.autodiscover_tasks(
     packages=[
         "core",
+        "apps",
     ]
 )

--- a/src/core/tasks.py
+++ b/src/core/tasks.py
@@ -10,7 +10,7 @@ from sentry_sdk.api import capture_exception
 
 from apps.users.models import Member
 from core.conf.environ import env
-from core.utils.mailer import Mailer
+from core.utils.mailer import Mailer, Message
 
 SingletonOrTask = Singleton if not env.bool("CELERY_ALWAYS_EAGER", default=False) else BaseTask
 
@@ -46,9 +46,11 @@ def send_order_created_email(order_id: int):
         Please process new book order <a href='{order_url}' target='_blank'>here</a>
     """
     mailer = Mailer(
-        subject="Book order created",
-        # to=env("LIBRARIAN_ADMIN_EMAIL"),
-        body=body,
+        Message(
+            subject="Book order created",
+            # to=env("LIBRARIAN_ADMIN_EMAIL"),
+            body=body,
+        )
     )
     email_sent = mailer.send()
 
@@ -74,9 +76,11 @@ def send_reservation_confirmed_email(order_id: int, reservation_id: int):
     """
 
     mailer = Mailer(
-        subject="Book is ready to be picked up",
-        # to=(order.member.email,),
-        body=body,
+        Message(
+            subject="Book is ready to be picked up",
+            # to=(order.member.email,),
+            body=body,
+        )
     )
     email_sent = mailer.send()
 
@@ -93,9 +97,11 @@ def send_member_registration_request_received(member_id: int):
         New member registration request received. Check <a href='{member_admin_url}' target='_blank'>here</a>
     """
     mailer = Mailer(
-        subject="Registration request received",
-        # to=env("LIBRARIAN_ADMIN_EMAIL"),
-        body=body,
+        Message(
+            subject="Registration request received",
+            # to=env("LIBRARIAN_ADMIN_EMAIL"),
+            body=body,
+        )
     )
     email_sent = mailer.send()
 
@@ -117,9 +123,11 @@ def send_registration_notification_to_member(member_id: int):
     """
 
     mailer = Mailer(
-        subject="Thanks! Your registration request received",
-        # to=env("member.email"),
-        body=body,
+        Message(
+            subject="Thanks! Your registration request received",
+            # to=env("member.email"),
+            body=body,
+        )
     )
 
     email_sent = mailer.send()
@@ -148,9 +156,11 @@ def send_password_reset_link_to_member(member_id: int):
     """
 
     mailer = Mailer(
-        subject="Password reset request",
-        # to=env("member.email"),
-        body=body,
+        Message(
+            subject="Password reset request",
+            # to=env("member.email"),
+            body=body,
+        )
     )
 
     email_sent = mailer.send()

--- a/src/core/tasks.py
+++ b/src/core/tasks.py
@@ -67,7 +67,7 @@ def send_reservation_confirmed_email(order_id: int, reservation_id: int):
         return {"error": f"Order with id {order_id} does not exist"}
 
     body = f"""
-        Hi {order.member.first_name or order.member.username}!<br />
+        Hi {order.member.name}!<br />
         "{order.book.title}" book is ready to be picked up. <br />
         Your Reservation ID: {order.reservation.pk} <br />
         Check all your reservations <a href='{reservations_url}' target='_blank'>here</a>
@@ -110,7 +110,7 @@ def send_registration_notification_to_member(member_id: int):
         return {"error": f"Member with id {member_id} does not exist"}
 
     body = f"""
-        Hi {member.first_name or member.username}! <br />
+        Hi {member.name}! <br />
         Your registration code: {member.registration_code}. <br />
         Please arrive to library to complete registration. <br />
         Don't forget to bring your ID card.
@@ -140,7 +140,7 @@ def send_password_reset_link_to_member(member_id: int):
     password_reset_url = urljoin(env("PRODUCTION_URL"), f"/reset-password/{member.password_reset_token}")
 
     body = f"""
-        Hi {member.first_name or member.username}! <br />
+        Hi {member.name}! <br />
         You requested password reset recently. <br />
         Please visit that link below to set a new password for your account: <br />
         <a href='{password_reset_url}' target='_blank'>Reset password</a> <br />

--- a/src/core/utils/mailer.py
+++ b/src/core/utils/mailer.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass
+from typing import NamedTuple
 
 import sentry_sdk
 from django.conf import settings
@@ -6,19 +6,11 @@ from django.core.mail import EmailMessage, get_connection
 from django_ses import SESBackend
 
 
-@dataclass
-class Message:
+class Message(NamedTuple):
     subject: str
     body: str
     from_email: str = settings.AWS_SES_FROM_EMAIL
-    to: list | tuple = (settings.AWS_SES_FROM_EMAIL,)
-
-    def __post_init__(self):
-        if not isinstance(self.to, (list, tuple)):
-            raise ValueError("'to' must be a list or tuple")
-
-    def __str__(self):
-        return self.subject
+    to: list[str] | tuple[str] = (settings.AWS_SES_FROM_EMAIL,)
 
 
 class HtmlEmailMessage(EmailMessage):
@@ -31,9 +23,8 @@ class Mailer:
         subject,
         body,
         from_email=settings.AWS_SES_FROM_EMAIL,
-        to=(settings.AWS_SES_FROM_EMAIL,),  # list or tuple
-        reply_to=("noreply@django-libraryms.fly.dev",),  # list or tuple
-        headers={},
+        to: list[str] | tuple[str] = (settings.AWS_SES_FROM_EMAIL,),
+        reply_to: list[str] | tuple[str] = ("noreply@django-libraryms.fly.dev",),
     ):
         self.email = HtmlEmailMessage(
             subject=subject,
@@ -41,7 +32,6 @@ class Mailer:
             from_email=from_email,
             to=to,
             reply_to=reply_to,
-            headers=headers,
         )
 
     def send(self) -> int:

--- a/src/core/utils/mailer.py
+++ b/src/core/utils/mailer.py
@@ -1,5 +1,28 @@
+from dataclasses import dataclass
+
+import sentry_sdk
 from django.conf import settings
-from django.core.mail import EmailMessage
+from django.core.mail import EmailMessage, get_connection
+from django_ses import SESBackend
+
+
+@dataclass
+class Message:
+    subject: str
+    body: str
+    from_email: str = settings.AWS_SES_FROM_EMAIL
+    to: list | tuple = (settings.AWS_SES_FROM_EMAIL,)
+
+    def __post_init__(self):
+        if not isinstance(self.to, (list, tuple)):
+            raise ValueError("'to' must be a list or tuple")
+
+    def __str__(self):
+        return self.subject
+
+
+class HtmlEmailMessage(EmailMessage):
+    content_subtype = "html"
 
 
 class Mailer:
@@ -12,21 +35,14 @@ class Mailer:
         reply_to=("noreply@django-libraryms.fly.dev",),  # list or tuple
         headers={},
     ):
-        self.email = EmailMessage(
+        self.email = HtmlEmailMessage(
             subject=subject,
-            body=self.compact_body(body),
+            body=Mailer.compact_body(body),
             from_email=from_email,
             to=to,
             reply_to=reply_to,
             headers=headers,
         )
-        self.email.content_subtype = "html"
-
-    @staticmethod
-    def compact_body(body) -> str:
-        "Strips whitespaces before/after and within each body line"
-
-        return "".join([line.strip() for line in body.split("\n")])
 
     def send(self) -> int:
         """
@@ -34,3 +50,45 @@ class Mailer:
         (which can be 0 or 1 since it can only send one message).
         """
         return self.email.send()
+
+    @classmethod
+    def compact_body(cls, body) -> str:
+        "Strips whitespaces before/after and within each body line"
+
+        return "".join([line.strip() for line in body.split("\n")])
+
+    @classmethod
+    def send_mass_mail(
+        cls, messages: list[Message], fail_silently=False, auth_user=None, auth_password=None, connection=None
+    ) -> tuple[int, list[EmailMessage]]:
+        """
+        Extends Django's send_mass_mail() to support sending mass emails as html by default.
+        """
+        connection: SESBackend = connection or get_connection(
+            username=auth_user,
+            password=auth_password,
+            fail_silently=fail_silently,
+        )
+        messages = [
+            HtmlEmailMessage(message.subject, cls.compact_body(message.body), message.from_email, message.to, connection=connection) for message in messages
+        ]
+
+        emails_sent = connection.send_messages(messages)
+
+        if fail_silently:
+            failed_delivery = [m for m in messages if m.extra_headers.get("status", 200) != 200]
+            for failed_email in failed_delivery:
+                sentry_sdk.capture_message(
+                    "Failed to send reminder email",
+                    extra={
+                        "status": failed_email.extra_headers["status"],
+                        "message": failed_email.extra_headers["message"],
+                        "reason": failed_email.extra_headers["reason"],
+                        "error_message": failed_email.extra_headers["error_message"],
+                        "error_code": failed_email.extra_headers["error_code"],
+                    },
+                )
+            # TODO: add failure emailure deliveries for retry in separate periodict task
+            # .e.g by saving all context in FailedEmail model
+
+        return emails_sent

--- a/tests/apps/books/test_send_reservation_term_reminder.py
+++ b/tests/apps/books/test_send_reservation_term_reminder.py
@@ -1,0 +1,136 @@
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from mixer.backend.django import mixer
+
+from apps.books.const import ReservationStatus
+from apps.books.models.book import Book, Reservation
+from apps.tasks import send_reservation_term_reminder
+from core.utils.mailer import Message
+
+todays_date = datetime(2024, 8, 31, 0, 0, tzinfo=timezone.utc)
+pytestmark = [
+    pytest.mark.django_db,
+    pytest.mark.freeze_time(todays_date.isoformat()),
+]
+
+
+def errored_ses_message_headers():
+    return {
+        "message": "Message",
+        "reason": "No clue",
+        "status": 500,
+        "error_message": "Failed to send email",
+        "error_code": 123,
+    }
+
+
+@pytest.fixture
+def mock_send_mass_mail(mocker):
+    return mocker.patch("apps.tasks.Mailer.send_mass_mail")
+
+
+@pytest.fixture
+def _mock_send_messages_with_failure(mocker):
+    def mock_send_messages_with_failure(failed_indices: list[int]):
+        def mock_send_messages(messages: list[Message]):
+            for i in failed_indices:
+                messages[i].extra_headers = errored_ses_message_headers()
+
+            return len(messages) - len(failed_indices)
+
+        get_connection_mock = mocker.patch("core.utils.mailer.get_connection")
+        get_connection_mock.return_value.send_messages.side_effect = mock_send_messages
+        return get_connection_mock
+
+    return mock_send_messages_with_failure
+
+
+@pytest.fixture
+def mock_sentry_capture_message(mocker):
+    return mocker.patch("core.utils.mailer.sentry_sdk.capture_message")
+
+
+@pytest.fixture
+def _create_book_reservations():
+    def create_books_and_reservations(due_in_days: list[int]):
+        amount = len(due_in_days)
+        books = mixer.cycle(amount).blend(Book)
+        for book, due_in_days in zip(books, due_in_days):
+            reservation = mixer.blend(Reservation, book=book, status=ReservationStatus.ISSUED, term=todays_date + timedelta(days=due_in_days))
+            book.reservation = reservation
+            book.save()
+
+    return create_books_and_reservations
+
+
+def test_no_reminders_sent():
+    result = send_reservation_term_reminder.delay().get()
+
+    assert result["sent"] == 0
+
+
+def test_send_1_reminder_with_default_due_in_days(_create_book_reservations):
+    _create_book_reservations(due_in_days=[14, 10, 2])
+
+    assert Reservation.objects.count() == 3
+    assert Book.objects.count() == 3
+
+    result = send_reservation_term_reminder.delay().get()
+
+    assert result["sent"] == 1
+
+
+def test_send_2_reminders(_create_book_reservations):
+    _create_book_reservations(due_in_days=[3, 3, 2])
+
+    result = send_reservation_term_reminder.delay(due_in_days=3).get()
+
+    assert result["sent"] == 2
+
+
+def test_individual_message_properties(_create_book_reservations, mock_send_mass_mail):
+    _create_book_reservations(due_in_days=[10, 2, 2])
+
+    send_reservation_term_reminder.delay(due_in_days=2)
+
+    messages = mock_send_mass_mail.call_args[0][0]
+    fail_silently = mock_send_mass_mail.call_args[1]["fail_silently"]
+    assert fail_silently
+    assert mock_send_mass_mail.call_count == 1
+    assert len(messages) == 2
+    assert messages[0].subject == messages[1].subject == "Reservation term is ending in 2 days"
+    assert messages[0].body != messages[1].body
+    assert "https://example.com/account/reservations/" in messages[0].body
+
+
+def test_single_failed_delivery_captured(_create_book_reservations, mock_sentry_capture_message, _mock_send_messages_with_failure):
+    _create_book_reservations(due_in_days=[10, 2, 2])
+    fail_first_index = 0
+    mocked_sent = _mock_send_messages_with_failure(failed_indices=[fail_first_index])
+
+    result = send_reservation_term_reminder.delay(due_in_days=2).get()
+
+    assert result == {"sent": 1}
+    messages = mocked_sent.return_value.send_messages.call_args[0][0]
+    assert len(messages) == 2
+    assert messages[fail_first_index].extra_headers == errored_ses_message_headers()
+
+    assert mock_sentry_capture_message.call_count == 1
+    sentry_message = mock_sentry_capture_message.call_args[0][0]
+    sentry_extra = mock_sentry_capture_message.call_args[1]
+    assert sentry_message == "Failed to send reminder email"
+    assert sentry_extra["extra"] == messages[fail_first_index].extra_headers
+
+
+def test_multiple_failed_deliveries_captured(_create_book_reservations, mock_sentry_capture_message, _mock_send_messages_with_failure):
+    _create_book_reservations(due_in_days=[10, 2, 2, 2, 2])
+    mocked_sent = _mock_send_messages_with_failure(failed_indices=[0, 1])
+
+    result = send_reservation_term_reminder.delay(due_in_days=2).get()
+
+    assert result == {"sent": 2}
+    messages = mocked_sent.return_value.send_messages.call_args[0][0]
+    assert len(messages) == 4
+
+    assert mock_sentry_capture_message.call_count == 2

--- a/tests/apps/users/test_send_member_registration_request_received.py
+++ b/tests/apps/users/test_send_member_registration_request_received.py
@@ -1,6 +1,7 @@
 import pytest
 
 from core.tasks import send_member_registration_request_received
+from core.utils.mailer import Message
 
 pytestmark = pytest.mark.django_db
 
@@ -11,8 +12,8 @@ def test_success(mock_mailer):
     result = send_member_registration_request_received.delay(member_id).get()
 
     assert result["sent"]
-    call_kwargs = mock_mailer.call_args.kwargs
-    assert call_kwargs["subject"] == "Registration request received"
-    assert "Hi admin!" in call_kwargs["body"]
-    assert "New member registration request received" in call_kwargs["body"]
-    assert "https://example.com/admin/users/member/1/change/" in call_kwargs["body"]
+    message: Message = mock_mailer.call_args[0][0]
+    assert message.subject == "Registration request received"
+    assert "Hi admin!" in message.body
+    assert "New member registration request received" in message.body
+    assert "https://example.com/admin/users/member/1/change/" in message.body

--- a/tests/apps/users/test_send_registration_notification_to_member.py
+++ b/tests/apps/users/test_send_registration_notification_to_member.py
@@ -3,6 +3,7 @@ from mixer.backend.django import mixer
 
 from apps.users.models import Member
 from core.tasks import send_registration_notification_to_member
+from core.utils.mailer import Message
 
 pytestmark = pytest.mark.django_db
 
@@ -21,12 +22,12 @@ def test_send_success_with_first_name_in_greeting(mock_mailer):
     result = send_registration_notification_to_member.delay(member.id).get()
 
     assert result["sent"]
-    call_kwargs = mock_mailer.call_args.kwargs
-    assert call_kwargs["subject"] == "Thanks! Your registration request received"
-    assert f"Hi {member.first_name}!" in call_kwargs["body"]
-    assert f"Your registration code: {member.registration_code}." in call_kwargs["body"]
-    assert "Please arrive to library to complete registration" in call_kwargs["body"]
-    assert "Don't forget to bring your ID card." in call_kwargs["body"]
+    message: Message = mock_mailer.call_args[0][0]
+    assert message.subject == "Thanks! Your registration request received"
+    assert f"Hi {member.first_name}!" in message.body
+    assert f"Your registration code: {member.registration_code}." in message.body
+    assert "Please arrive to library to complete registration" in message.body
+    assert "Don't forget to bring your ID card." in message.body
 
 
 def test_send_success_with_username_in_greeting(mock_mailer):
@@ -34,4 +35,5 @@ def test_send_success_with_username_in_greeting(mock_mailer):
 
     send_registration_notification_to_member.delay(member.id).get()
 
-    assert f"Hi {member.username}!" in mock_mailer.call_args.kwargs["body"]
+    message: Message = mock_mailer.call_args[0][0]
+    assert f"Hi {member.username}!" in message.body

--- a/tests/core/api/test_exception_handler.py
+++ b/tests/core/api/test_exception_handler.py
@@ -1,5 +1,4 @@
 import pytest
-from django.utils.translation import gettext_lazy as _
 from rest_framework.exceptions import APIException, Throttled
 from rest_framework.views import APIView
 
@@ -24,7 +23,7 @@ def test_drf_exception_handler_throttled(api_request, api_view):
 
     assert response is not None
     assert response.status_code == 429
-    assert response.data["detail"] == _("Too Many Requests")
+    assert "Too Many Requests" in response.data["detail"]
 
 
 def test_drf_exception_handler_non_throttled(api_request, api_view):
@@ -36,7 +35,7 @@ def test_drf_exception_handler_non_throttled(api_request, api_view):
     assert response is not None
     assert response.status_code == 500
     assert "detail" in response.data
-    assert response.data["detail"] != _("Too Many Requests")
+    assert "Too Many Requests" not in response.data["detail"]
 
 
 def test_drf_exception_handler_non_drf_exception(api_request, api_view):

--- a/tests/core/api/test_exception_handler.py
+++ b/tests/core/api/test_exception_handler.py
@@ -1,4 +1,5 @@
 import pytest
+from django.utils.translation import gettext_lazy as _
 from rest_framework.exceptions import APIException, Throttled
 from rest_framework.views import APIView
 
@@ -23,7 +24,7 @@ def test_drf_exception_handler_throttled(api_request, api_view):
 
     assert response is not None
     assert response.status_code == 429
-    assert "Too Many Requests" in response.data["detail"]
+    assert response.data["detail"] == _("Too Many Requests")
 
 
 def test_drf_exception_handler_non_throttled(api_request, api_view):
@@ -35,7 +36,7 @@ def test_drf_exception_handler_non_throttled(api_request, api_view):
     assert response is not None
     assert response.status_code == 500
     assert "detail" in response.data
-    assert "Too Many Requests" not in response.data["detail"]
+    assert response.data["detail"] != _("Too Many Requests")
 
 
 def test_drf_exception_handler_non_drf_exception(api_request, api_view):

--- a/tests/core/tasks/test_send_order_created_email.py
+++ b/tests/core/tasks/test_send_order_created_email.py
@@ -1,4 +1,5 @@
 from core.tasks import send_order_created_email
+from core.utils.mailer import Message
 
 
 def test_send_order_created_email(mock_mailer):
@@ -7,8 +8,8 @@ def test_send_order_created_email(mock_mailer):
     result = send_order_created_email.delay(order_id).get()
 
     assert result["sent"] == 1
-    call_kwargs = mock_mailer.call_args.kwargs
-    assert call_kwargs["subject"] == "Book order created"
-    assert "Hi admin!" in call_kwargs["body"]
-    assert "Please process new book order" in call_kwargs["body"]
-    assert "https://example.com/admin/books/order/1/change/" in call_kwargs["body"]
+    message: Message = mock_mailer.call_args[0][0]
+    assert message.subject == "Book order created"
+    assert "Hi admin!" in message.body
+    assert "Please process new book order" in message.body
+    assert "https://example.com/admin/books/order/1/change/" in message.body


### PR DESCRIPTION
Adds a task, assumed to be used as periodic with the following purpose:
- For each reservation that is going to be due in `due_in_days`, send a reminder email to a member
- Fail silently mass sending and report every failed email delivery to sentry for now(based on [error headers](https://github.com/django-ses/django-ses/blob/ff79d69c119464c22ea15a071fed38a13f6b3acc/django_ses/__init__.py#L199-L206) set by `django-ses` send handler in case of exception
    - later on, each failed email could be picked up by a separate retry job which would try to resend failed emails(based in error nature)

### Extras:
- adds status filter to Order/Reservation list views.
- Leverages `Message` named tuple for single and bulk email sending in Mailer class. 
   - that allowed to pass defaults in a single place conveniently
 - adds `HtmlEmailMessage` with content_subtype override for sending emails as HTML by default