### PR TITLE
pytest optimizations

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -61,8 +61,8 @@ jobs:
       - name: build
         uses: ./.github/actions/build
 
-      - name: test
-        run: make test
+      - name: test with coverage
+        run: make testwithcoverage
 
       - name: Generate coverage badge
         if: github.ref == 'refs/heads/main'

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,11 @@
 manage = poetry run python src/manage.py
 test = poetry run pytest --capture=fd --verbosity=0
 testinparallel = $(test) --numprocesses auto
+testwithcoverage = $(test) \
+		--cov=apps --cov=core \
+		--cov-report=term-missing:skip-covered \
+		--cov-fail-under=90
+
 PORT := 7070
 
 server:
@@ -36,10 +41,13 @@ test:
 	poetry run pytest --dead-fixtures
 
 testwithcoverage:
-	$(test) \
-		--cov=apps --cov=core --cov-report=html:htmlcov \
-		--cov-report=term-missing:skip-covered \
-		--cov-fail-under=90
+	$(testwithcoverage)
+
+testwithhtmlcoverage:
+	$(testwithcoverage) --cov-report=html:htmlcov
+
+opencoverage:
+	open ./htmlcov/index.html
 
 fmt:
 	poetry run ruff format src tests
@@ -66,6 +74,3 @@ upbuild:
 
 upbuildnocache:
 	docker compose up -d --build --force-recreate
-
-opencoverage:
-	open ./htmlcov/index.html

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 manage = poetry run python src/manage.py
-testinparallel = poetry run pytest --capture=fd --verbosity=0 --numprocesses auto --dist loadscope
+test = poetry run pytest --capture=fd --verbosity=0
+testinparallel = $(test) --numprocesses auto
 PORT := 7070
 
 server:
@@ -35,7 +36,7 @@ test:
 	poetry run pytest --dead-fixtures
 
 testwithcoverage:
-	$(testinparallel) \
+	$(test) \
 		--cov=apps --cov=core --cov-report=html:htmlcov \
 		--cov-report=term-missing:skip-covered \
 		--cov-fail-under=90

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 manage = poetry run python src/manage.py
+testinparallel = poetry run pytest --verbosity=0 --numprocesses auto --dist loadscope
 PORT := 7070
 
 server:
@@ -30,8 +31,14 @@ build_backend:
 	./scripts/build-backend.sh
 
 test:
-	poetry run pytest --cov=apps --cov=core --cov-report=html:htmlcov --cov-report=term-missing:skip-covered --cov-fail-under=90
+	$(testinparallel)
 	poetry run pytest --dead-fixtures
+
+testwithcoverage:
+	$(testinparallel) \
+		--cov=apps --cov=core --cov-report=html:htmlcov \
+		--cov-report=term-missing:skip-covered \
+		--cov-fail-under=90
 
 fmt:
 	poetry run ruff format src tests

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 manage = poetry run python src/manage.py
-testinparallel = poetry run pytest --verbosity=0 --numprocesses auto --dist loadscope
+testinparallel = poetry run pytest --capture=fd --verbosity=0 --numprocesses auto --dist loadscope
 PORT := 7070
 
 server:

--- a/poetry.lock
+++ b/poetry.lock
@@ -919,6 +919,20 @@ python-jose = ["python-jose (==3.3.0)"]
 test = ["cryptography", "freezegun", "pytest", "pytest-cov", "pytest-django", "pytest-xdist", "tox"]
 
 [[package]]
+name = "execnet"
+version = "2.1.1"
+description = "execnet: rapid multi-Python deployment"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "execnet-2.1.1-py3-none-any.whl", hash = "sha256:26dee51f1b80cebd6d0ca8e74dd8745419761d3bef34163928cbebbdc4749fdc"},
+    {file = "execnet-2.1.1.tar.gz", hash = "sha256:5189b52c6121c24feae288166ab41b32549c7e2348652736540b9e6e7d4e72e3"},
+]
+
+[package.extras]
+testing = ["hatch", "pre-commit", "pytest", "tox"]
+
+[[package]]
 name = "faker"
 version = "12.0.1"
 description = "Faker is a Python package that generates fake data for you."
@@ -1560,6 +1574,26 @@ pytest = ">=6.2.5"
 dev = ["pre-commit", "pytest-asyncio", "tox"]
 
 [[package]]
+name = "pytest-xdist"
+version = "3.6.1"
+description = "pytest xdist plugin for distributed testing, most importantly across multiple CPUs"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "pytest_xdist-3.6.1-py3-none-any.whl", hash = "sha256:9ed4adfb68a016610848639bb7e02c9352d5d9f03d04809919e2dafc3be4cca7"},
+    {file = "pytest_xdist-3.6.1.tar.gz", hash = "sha256:ead156a4db231eec769737f57668ef58a2084a34b2e55c4a8fa20d861107300d"},
+]
+
+[package.dependencies]
+execnet = ">=2.1"
+pytest = ">=7.0.0"
+
+[package.extras]
+psutil = ["psutil (>=3.0)"]
+setproctitle = ["setproctitle"]
+testing = ["filelock"]
+
+[[package]]
 name = "python-crontab"
 version = "3.2.0"
 description = "Python Crontab API"
@@ -1904,4 +1938,4 @@ brotli = ["brotli"]
 [metadata]
 lock-version = "2.0"
 python-versions = "~3.11"
-content-hash = "de67eb8d3ad76ed9bb937025fbeaebd2c386e752f6b5c04a8de41fd63667a279"
+content-hash = "171a7e88171bbc4ed345071074b1006cd76623bf35cae5c06e23356a30466914"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,7 @@ pytest-mock = "^3.14.0"
 ruff = "^0.5.1"
 toml-sort = "^0.23.1"
 types-requests = "^2.32.0.20240712"
+pytest-xdist = "^3.6.1"
 
 [tool.coverage.report]
 omit = [
@@ -59,6 +60,8 @@ omit = [
     "src/core/middleware/sql.py",
     "src/core/wsgi.py",
 ]
+[tool.coverage.run]
+disable_warnings = ["module-not-measured"]
 
 [tool.pytest.ini_options]
 DJANGO_SETTINGS_MODULE = "core.settings"
@@ -67,7 +70,7 @@ addopts = [
     "--reuse-db",
     "-p no:warnings",
     "-s",
-    "-v",
+    "--verbosity=1",
 ]
 env = [
     "CELERY_ALWAYS_EAGER = 1",
@@ -76,9 +79,6 @@ env = [
     "DISABLE_THROTTLING = 1",
     "PRODUCTION_URL = https://example.com",
     "THROTTLING_ANON_RATE = 3/minute",
-]
-markers = [
-    "skip_create_books: test_book_list_view.py",
 ]
 python_files = "test*.py"
 pythonpath = ". src"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,9 +61,6 @@ omit = [
     "src/core/wsgi.py",
 ]
 
-[tool.coverage.run]
-disable_warnings = ["module-not-measured"]
-
 [tool.pytest.ini_options]
 DJANGO_SETTINGS_MODULE = "core.settings"
 addopts = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,7 +71,7 @@ addopts = [
     "--reuse-db",
     "--verbosity=1",
     "-p no:warnings",
-    "-s",
+    "--capture=no", # ouputs prints statements / db errors(if any, like integrity errors)
 ]
 env = [
     "CELERY_ALWAYS_EAGER = 1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,7 @@ omit = [
 [tool.pytest.ini_options]
 DJANGO_SETTINGS_MODULE = "core.settings"
 addopts = [
-    "--capture=no",  # ouputs prints statements / db errors(if any, like integrity errors)
+    "--capture=no",  # ouputs print statements / db warnings(e.g. Integrity errors)
     "--maxfail=1",
     "--reuse-db",
     "--verbosity=1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,11 +67,11 @@ disable_warnings = ["module-not-measured"]
 [tool.pytest.ini_options]
 DJANGO_SETTINGS_MODULE = "core.settings"
 addopts = [
+    "--capture=no",  # ouputs prints statements / db errors(if any, like integrity errors)
     "--maxfail=1",
     "--reuse-db",
     "--verbosity=1",
     "-p no:warnings",
-    "--capture=no", # ouputs prints statements / db errors(if any, like integrity errors)
 ]
 env = [
     "CELERY_ALWAYS_EAGER = 1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,10 +48,10 @@ pytest-django = "^4.8.0"
 pytest-env = "^1.1.3"
 pytest-freezegun = "^0.4.2"
 pytest-mock = "^3.14.0"
+pytest-xdist = "^3.6.1"
 ruff = "^0.5.1"
 toml-sort = "^0.23.1"
 types-requests = "^2.32.0.20240712"
-pytest-xdist = "^3.6.1"
 
 [tool.coverage.report]
 omit = [
@@ -60,6 +60,7 @@ omit = [
     "src/core/middleware/sql.py",
     "src/core/wsgi.py",
 ]
+
 [tool.coverage.run]
 disable_warnings = ["module-not-measured"]
 
@@ -68,9 +69,9 @@ DJANGO_SETTINGS_MODULE = "core.settings"
 addopts = [
     "--maxfail=1",
     "--reuse-db",
+    "--verbosity=1",
     "-p no:warnings",
     "-s",
-    "--verbosity=1",
 ]
 env = [
     "CELERY_ALWAYS_EAGER = 1",

--- a/tests/apps/books/test_publisher.py
+++ b/tests/apps/books/test_publisher.py
@@ -1,4 +1,5 @@
 import pytest
+from django.db import IntegrityError
 from mixer.backend.django import mixer
 
 from apps.books.models import Publisher
@@ -19,7 +20,7 @@ def test_publisher_str_method():
 
 def test_publisher_name_unique():
     mixer.blend(Publisher, name="Unique Publisher")
-    with pytest.raises(Exception):
+    with pytest.raises(IntegrityError):
         mixer.blend(Publisher, name="Unique Publisher")
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,7 +11,6 @@ pytest_plugins = [
     "tests.fixtures.api",
     "tests.fixtures.users",
     "tests.fixtures.books",
-    "tests.fixtures.mailing",
 ]
 
 
@@ -36,3 +35,10 @@ def _create_tmp_index_template():
 
     # teardown
     os.remove(f.name)
+
+
+@pytest.fixture(autouse=True)
+def mock_mailer(mocker):
+    mocked = mocker.patch("core.tasks.Mailer")
+    mocked.return_value.send.return_value = 1
+    return mocked

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,11 +1,6 @@
 import os
 
-import django
 import pytest
-
-# this allows to run pytest --help / pytest --version without erorrs :shrug:
-django.setup()
-
 
 pytest_plugins = [
     "tests.fixtures.api",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,11 @@
 import os
 
+import django
 import pytest
+
+# this allows to run pytest --help / pytest --version without erorrs :shrug:
+django.setup()
+
 
 pytest_plugins = [
     "tests.fixtures.api",

--- a/tests/core/test_mailer.py
+++ b/tests/core/test_mailer.py
@@ -1,0 +1,59 @@
+import pytest
+from django.core.mail import EmailMessage
+
+from src.core.utils.mailer import HtmlEmailMessage, Mailer, Message
+
+
+@pytest.fixture
+def sample_message():
+    return Message(subject="Test Subject", body="Test Body", from_email="from@example.com", to=["to@example.com"], reply_to=["reply@example.com"])
+
+
+def test_mailer_init(sample_message):
+    mailer = Mailer(sample_message)
+    assert isinstance(mailer.email, HtmlEmailMessage)
+
+    assert mailer.email.subject == "Test Subject"
+    assert mailer.email.body == "Test Body"
+    assert mailer.email.from_email == "from@example.com"
+    assert mailer.email.to == ["to@example.com"]
+    assert mailer.email.reply_to == ["reply@example.com"]
+
+
+def test_mailer_init_compact_body():
+    message = Message(subject="Test Subject", body="  Line 1  \n  Line 2  \n  Line 3  ", from_email="from@example.com", to=["to@example.com"])
+    mailer = Mailer(message)
+
+    assert mailer.email.body == "Line 1Line 2Line 3"
+
+
+def test_mailer_compact_body():
+    input_body = """
+    This is a test email body.<br/>
+    It has multiple lines.
+        Some lines have extra indentation.
+
+    There are also empty lines.
+    """
+    expected_output = "This is a test email body.<br/>It has multiple lines.Some lines have extra indentation.There are also empty lines."
+
+    result = Mailer.compact_body(input_body)
+    assert result == expected_output
+
+
+def test_mailer_send(sample_message, mocker):
+    mailer = Mailer(sample_message)
+    mock_send = mocker.patch.object(EmailMessage, "send", return_value=1)
+    result = mailer.send()
+
+    assert result == 1
+    mock_send.assert_called_once()
+
+
+def test_mailer_send_failure(sample_message, mocker):
+    mailer = Mailer(sample_message)
+    mock_send = mocker.patch.object(EmailMessage, "send", return_value=0)
+    result = mailer.send()
+
+    assert result == 0
+    mock_send.assert_called_once()

--- a/tests/fixtures/api.py
+++ b/tests/fixtures/api.py
@@ -4,20 +4,22 @@ from rest_framework.test import APIClient
 from rest_framework_simplejwt.tokens import RefreshToken
 
 
-@pytest.fixture
-def client():
+@pytest.fixture(scope="session")
+def client() -> APIClient:
     return APIClient()
 
 
 @pytest.fixture
-def authenticated_client(client):
+def authenticated_client(client: APIClient):
     def _client(user) -> APIClient:
         refresh = RefreshToken.for_user(user)
         client.credentials(HTTP_AUTHORIZATION=f"Bearer {refresh.access_token}")
         client.cookies[settings.SIMPLE_JWT["REFRESH_TOKEN_COOKIE_NAME"]] = str(refresh)
         return client
 
-    return _client
+    yield _client
+
+    client.logout()
 
 
 @pytest.fixture

--- a/tests/fixtures/mailing.py
+++ b/tests/fixtures/mailing.py
@@ -1,10 +1,8 @@
-from unittest.mock import patch
-
 import pytest
 
 
-@pytest.fixture
-def mock_mailer():
-    with patch("core.tasks.Mailer") as MockMailer:
-        MockMailer.return_value.send.return_value = 1
-        yield MockMailer
+@pytest.fixture(autouse=True)
+def mock_mailer(mocker):
+    mocked = mocker.patch("core.tasks.Mailer")
+    mocked.return_value.send.return_value = 1
+    return mocked

--- a/tests/fixtures/mailing.py
+++ b/tests/fixtures/mailing.py
@@ -1,8 +1,0 @@
-import pytest
-
-
-@pytest.fixture(autouse=True)
-def mock_mailer(mocker):
-    mocked = mocker.patch("core.tasks.Mailer")
-    mocked.return_value.send.return_value = 1
-    return mocked


### PR DESCRIPTION
- Separates test and test with coverage commands
- Lerages `pytest-xdist` plugin for multi-threaded testing.
  - although, for coverage did not get it working properly at this point, 
   hence  CI will still  be using CI a single-threaded test command
- optimizes a couple of tests/fixtures, e.g. to reduce the number of DB calls
- removes captured output in CI test run, leaving that only for local dev(defaults in pyproject.toml)