### PR TITLE
Deploy FRONTEND_ASSETS_VERSION secret via triggerable GH workflow

### DIFF
--- a/.github/workflows/deploy_frontend_assets_version.yml
+++ b/.github/workflows/deploy_frontend_assets_version.yml
@@ -1,0 +1,20 @@
+name: CI/CD
+
+on:
+  workflow_dispatch:
+    inputs:
+      frontend_assets_version:
+        description: 'Frontend assets version'
+        required: true
+
+jobs:
+  deploy-frontend-assets-version:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: superfly/flyctl-actions/setup-flyctl@master
+      - name: Deploy FRONTEND_ASSETS_VERSION secret
+        run: |
+          flyctl secrets set FRONTEND_ASSETS_VERSION=${{ github.event.inputs.frontend_assets_version }}
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,12 +14,6 @@ on:
     branches:
         - main
 
-  workflow_dispatch:
-    inputs:
-      frontend_version:
-        description: 'Frontend assets version'
-        required: true
-
 env:
   CI: true
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -109,17 +103,5 @@ jobs:
           submodules: 'recursive'
       - uses: superfly/flyctl-actions/setup-flyctl@master
       - run: flyctl deploy
-        env:
-          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
-
-  deploy-frontend-version:
-    if: github.event_name == 'workflow_dispatch'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: superfly/flyctl-actions/setup-flyctl@master
-      - name: Deploy frontend version secret
-        run: |
-          flyctl secrets set FRONTEND_ASSETS_VERSION=${{ github.event.inputs.frontend_version }}
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,14 @@ on:
     #   - '.dockerignore'
       - 'demo/**'
   pull_request:
+    branches:
+        - main
 
+  workflow_dispatch:
+    inputs:
+      frontend_version:
+        description: 'Frontend assets version'
+        required: true
 
 env:
   CI: true
@@ -102,5 +109,17 @@ jobs:
           submodules: 'recursive'
       - uses: superfly/flyctl-actions/setup-flyctl@master
       - run: flyctl deploy
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+
+  deploy-frontend-version:
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: superfly/flyctl-actions/setup-flyctl@master
+      - name: Deploy frontend version secret
+        run: |
+          flyctl secrets set FRONTEND_ASSETS_VERSION=${{ github.event.inputs.frontend_version }}
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}


### PR DESCRIPTION
Follow-up for https://github.com/peacefulseeker/django-libraryms/pull/34
On-demand triggerable workflow to deploy new frontend assets version specified.