### PR TITLE
Amazon SES templated emails single and in bulk

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -97,6 +97,417 @@ s3transfer = ">=0.10.0,<0.11.0"
 crt = ["botocore[crt] (>=1.21.0,<2.0a0)"]
 
 [[package]]
+name = "boto3-stubs"
+version = "1.35.13.post1"
+description = "Type annotations for boto3 1.35.13 generated with mypy-boto3-builder 8.0.1"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "boto3_stubs-1.35.13.post1-py3-none-any.whl", hash = "sha256:7be9a5006d623092f45c19d06000f99cf39e84d7e4002efb0b91a7db25429aaf"},
+    {file = "boto3_stubs-1.35.13.post1.tar.gz", hash = "sha256:8a88a189d37c3323dff6b5a6cfe1fe9b1f4c219512837300e581716e46d0eaea"},
+]
+
+[package.dependencies]
+botocore-stubs = "*"
+mypy-boto3-s3 = {version = ">=1.35.0,<1.36.0", optional = true, markers = "extra == \"s3\""}
+mypy-boto3-ses = {version = ">=1.35.0,<1.36.0", optional = true, markers = "extra == \"ses\""}
+mypy-boto3-sesv2 = {version = ">=1.35.0,<1.36.0", optional = true, markers = "extra == \"sesv2\""}
+types-s3transfer = "*"
+typing-extensions = {version = ">=4.1.0", markers = "python_version < \"3.12\""}
+
+[package.extras]
+accessanalyzer = ["mypy-boto3-accessanalyzer (>=1.35.0,<1.36.0)"]
+account = ["mypy-boto3-account (>=1.35.0,<1.36.0)"]
+acm = ["mypy-boto3-acm (>=1.35.0,<1.36.0)"]
+acm-pca = ["mypy-boto3-acm-pca (>=1.35.0,<1.36.0)"]
+all = ["mypy-boto3-accessanalyzer (>=1.35.0,<1.36.0)", "mypy-boto3-account (>=1.35.0,<1.36.0)", "mypy-boto3-acm (>=1.35.0,<1.36.0)", "mypy-boto3-acm-pca (>=1.35.0,<1.36.0)", "mypy-boto3-amp (>=1.35.0,<1.36.0)", "mypy-boto3-amplify (>=1.35.0,<1.36.0)", "mypy-boto3-amplifybackend (>=1.35.0,<1.36.0)", "mypy-boto3-amplifyuibuilder (>=1.35.0,<1.36.0)", "mypy-boto3-apigateway (>=1.35.0,<1.36.0)", "mypy-boto3-apigatewaymanagementapi (>=1.35.0,<1.36.0)", "mypy-boto3-apigatewayv2 (>=1.35.0,<1.36.0)", "mypy-boto3-appconfig (>=1.35.0,<1.36.0)", "mypy-boto3-appconfigdata (>=1.35.0,<1.36.0)", "mypy-boto3-appfabric (>=1.35.0,<1.36.0)", "mypy-boto3-appflow (>=1.35.0,<1.36.0)", "mypy-boto3-appintegrations (>=1.35.0,<1.36.0)", "mypy-boto3-application-autoscaling (>=1.35.0,<1.36.0)", "mypy-boto3-application-insights (>=1.35.0,<1.36.0)", "mypy-boto3-application-signals (>=1.35.0,<1.36.0)", "mypy-boto3-applicationcostprofiler (>=1.35.0,<1.36.0)", "mypy-boto3-appmesh (>=1.35.0,<1.36.0)", "mypy-boto3-apprunner (>=1.35.0,<1.36.0)", "mypy-boto3-appstream (>=1.35.0,<1.36.0)", "mypy-boto3-appsync (>=1.35.0,<1.36.0)", "mypy-boto3-apptest (>=1.35.0,<1.36.0)", "mypy-boto3-arc-zonal-shift (>=1.35.0,<1.36.0)", "mypy-boto3-artifact (>=1.35.0,<1.36.0)", "mypy-boto3-athena (>=1.35.0,<1.36.0)", "mypy-boto3-auditmanager (>=1.35.0,<1.36.0)", "mypy-boto3-autoscaling (>=1.35.0,<1.36.0)", "mypy-boto3-autoscaling-plans (>=1.35.0,<1.36.0)", "mypy-boto3-b2bi (>=1.35.0,<1.36.0)", "mypy-boto3-backup (>=1.35.0,<1.36.0)", "mypy-boto3-backup-gateway (>=1.35.0,<1.36.0)", "mypy-boto3-batch (>=1.35.0,<1.36.0)", "mypy-boto3-bcm-data-exports (>=1.35.0,<1.36.0)", "mypy-boto3-bedrock (>=1.35.0,<1.36.0)", "mypy-boto3-bedrock-agent (>=1.35.0,<1.36.0)", "mypy-boto3-bedrock-agent-runtime (>=1.35.0,<1.36.0)", "mypy-boto3-bedrock-runtime (>=1.35.0,<1.36.0)", "mypy-boto3-billingconductor (>=1.35.0,<1.36.0)", "mypy-boto3-braket (>=1.35.0,<1.36.0)", "mypy-boto3-budgets (>=1.35.0,<1.36.0)", "mypy-boto3-ce (>=1.35.0,<1.36.0)", "mypy-boto3-chatbot (>=1.35.0,<1.36.0)", "mypy-boto3-chime (>=1.35.0,<1.36.0)", "mypy-boto3-chime-sdk-identity (>=1.35.0,<1.36.0)", "mypy-boto3-chime-sdk-media-pipelines (>=1.35.0,<1.36.0)", "mypy-boto3-chime-sdk-meetings (>=1.35.0,<1.36.0)", "mypy-boto3-chime-sdk-messaging (>=1.35.0,<1.36.0)", "mypy-boto3-chime-sdk-voice (>=1.35.0,<1.36.0)", "mypy-boto3-cleanrooms (>=1.35.0,<1.36.0)", "mypy-boto3-cleanroomsml (>=1.35.0,<1.36.0)", "mypy-boto3-cloud9 (>=1.35.0,<1.36.0)", "mypy-boto3-cloudcontrol (>=1.35.0,<1.36.0)", "mypy-boto3-clouddirectory (>=1.35.0,<1.36.0)", "mypy-boto3-cloudformation (>=1.35.0,<1.36.0)", "mypy-boto3-cloudfront (>=1.35.0,<1.36.0)", "mypy-boto3-cloudfront-keyvaluestore (>=1.35.0,<1.36.0)", "mypy-boto3-cloudhsm (>=1.35.0,<1.36.0)", "mypy-boto3-cloudhsmv2 (>=1.35.0,<1.36.0)", "mypy-boto3-cloudsearch (>=1.35.0,<1.36.0)", "mypy-boto3-cloudsearchdomain (>=1.35.0,<1.36.0)", "mypy-boto3-cloudtrail (>=1.35.0,<1.36.0)", "mypy-boto3-cloudtrail-data (>=1.35.0,<1.36.0)", "mypy-boto3-cloudwatch (>=1.35.0,<1.36.0)", "mypy-boto3-codeartifact (>=1.35.0,<1.36.0)", "mypy-boto3-codebuild (>=1.35.0,<1.36.0)", "mypy-boto3-codecatalyst (>=1.35.0,<1.36.0)", "mypy-boto3-codecommit (>=1.35.0,<1.36.0)", "mypy-boto3-codeconnections (>=1.35.0,<1.36.0)", "mypy-boto3-codedeploy (>=1.35.0,<1.36.0)", "mypy-boto3-codeguru-reviewer (>=1.35.0,<1.36.0)", "mypy-boto3-codeguru-security (>=1.35.0,<1.36.0)", "mypy-boto3-codeguruprofiler (>=1.35.0,<1.36.0)", "mypy-boto3-codepipeline (>=1.35.0,<1.36.0)", "mypy-boto3-codestar-connections (>=1.35.0,<1.36.0)", "mypy-boto3-codestar-notifications (>=1.35.0,<1.36.0)", "mypy-boto3-cognito-identity (>=1.35.0,<1.36.0)", "mypy-boto3-cognito-idp (>=1.35.0,<1.36.0)", "mypy-boto3-cognito-sync (>=1.35.0,<1.36.0)", "mypy-boto3-comprehend (>=1.35.0,<1.36.0)", "mypy-boto3-comprehendmedical (>=1.35.0,<1.36.0)", "mypy-boto3-compute-optimizer (>=1.35.0,<1.36.0)", "mypy-boto3-config (>=1.35.0,<1.36.0)", "mypy-boto3-connect (>=1.35.0,<1.36.0)", "mypy-boto3-connect-contact-lens (>=1.35.0,<1.36.0)", "mypy-boto3-connectcampaigns (>=1.35.0,<1.36.0)", "mypy-boto3-connectcases (>=1.35.0,<1.36.0)", "mypy-boto3-connectparticipant (>=1.35.0,<1.36.0)", "mypy-boto3-controlcatalog (>=1.35.0,<1.36.0)", "mypy-boto3-controltower (>=1.35.0,<1.36.0)", "mypy-boto3-cost-optimization-hub (>=1.35.0,<1.36.0)", "mypy-boto3-cur (>=1.35.0,<1.36.0)", "mypy-boto3-customer-profiles (>=1.35.0,<1.36.0)", "mypy-boto3-databrew (>=1.35.0,<1.36.0)", "mypy-boto3-dataexchange (>=1.35.0,<1.36.0)", "mypy-boto3-datapipeline (>=1.35.0,<1.36.0)", "mypy-boto3-datasync (>=1.35.0,<1.36.0)", "mypy-boto3-datazone (>=1.35.0,<1.36.0)", "mypy-boto3-dax (>=1.35.0,<1.36.0)", "mypy-boto3-deadline (>=1.35.0,<1.36.0)", "mypy-boto3-detective (>=1.35.0,<1.36.0)", "mypy-boto3-devicefarm (>=1.35.0,<1.36.0)", "mypy-boto3-devops-guru (>=1.35.0,<1.36.0)", "mypy-boto3-directconnect (>=1.35.0,<1.36.0)", "mypy-boto3-discovery (>=1.35.0,<1.36.0)", "mypy-boto3-dlm (>=1.35.0,<1.36.0)", "mypy-boto3-dms (>=1.35.0,<1.36.0)", "mypy-boto3-docdb (>=1.35.0,<1.36.0)", "mypy-boto3-docdb-elastic (>=1.35.0,<1.36.0)", "mypy-boto3-drs (>=1.35.0,<1.36.0)", "mypy-boto3-ds (>=1.35.0,<1.36.0)", "mypy-boto3-dynamodb (>=1.35.0,<1.36.0)", "mypy-boto3-dynamodbstreams (>=1.35.0,<1.36.0)", "mypy-boto3-ebs (>=1.35.0,<1.36.0)", "mypy-boto3-ec2 (>=1.35.0,<1.36.0)", "mypy-boto3-ec2-instance-connect (>=1.35.0,<1.36.0)", "mypy-boto3-ecr (>=1.35.0,<1.36.0)", "mypy-boto3-ecr-public (>=1.35.0,<1.36.0)", "mypy-boto3-ecs (>=1.35.0,<1.36.0)", "mypy-boto3-efs (>=1.35.0,<1.36.0)", "mypy-boto3-eks (>=1.35.0,<1.36.0)", "mypy-boto3-eks-auth (>=1.35.0,<1.36.0)", "mypy-boto3-elastic-inference (>=1.35.0,<1.36.0)", "mypy-boto3-elasticache (>=1.35.0,<1.36.0)", "mypy-boto3-elasticbeanstalk (>=1.35.0,<1.36.0)", "mypy-boto3-elastictranscoder (>=1.35.0,<1.36.0)", "mypy-boto3-elb (>=1.35.0,<1.36.0)", "mypy-boto3-elbv2 (>=1.35.0,<1.36.0)", "mypy-boto3-emr (>=1.35.0,<1.36.0)", "mypy-boto3-emr-containers (>=1.35.0,<1.36.0)", "mypy-boto3-emr-serverless (>=1.35.0,<1.36.0)", "mypy-boto3-entityresolution (>=1.35.0,<1.36.0)", "mypy-boto3-es (>=1.35.0,<1.36.0)", "mypy-boto3-events (>=1.35.0,<1.36.0)", "mypy-boto3-evidently (>=1.35.0,<1.36.0)", "mypy-boto3-finspace (>=1.35.0,<1.36.0)", "mypy-boto3-finspace-data (>=1.35.0,<1.36.0)", "mypy-boto3-firehose (>=1.35.0,<1.36.0)", "mypy-boto3-fis (>=1.35.0,<1.36.0)", "mypy-boto3-fms (>=1.35.0,<1.36.0)", "mypy-boto3-forecast (>=1.35.0,<1.36.0)", "mypy-boto3-forecastquery (>=1.35.0,<1.36.0)", "mypy-boto3-frauddetector (>=1.35.0,<1.36.0)", "mypy-boto3-freetier (>=1.35.0,<1.36.0)", "mypy-boto3-fsx (>=1.35.0,<1.36.0)", "mypy-boto3-gamelift (>=1.35.0,<1.36.0)", "mypy-boto3-glacier (>=1.35.0,<1.36.0)", "mypy-boto3-globalaccelerator (>=1.35.0,<1.36.0)", "mypy-boto3-glue (>=1.35.0,<1.36.0)", "mypy-boto3-grafana (>=1.35.0,<1.36.0)", "mypy-boto3-greengrass (>=1.35.0,<1.36.0)", "mypy-boto3-greengrassv2 (>=1.35.0,<1.36.0)", "mypy-boto3-groundstation (>=1.35.0,<1.36.0)", "mypy-boto3-guardduty (>=1.35.0,<1.36.0)", "mypy-boto3-health (>=1.35.0,<1.36.0)", "mypy-boto3-healthlake (>=1.35.0,<1.36.0)", "mypy-boto3-iam (>=1.35.0,<1.36.0)", "mypy-boto3-identitystore (>=1.35.0,<1.36.0)", "mypy-boto3-imagebuilder (>=1.35.0,<1.36.0)", "mypy-boto3-importexport (>=1.35.0,<1.36.0)", "mypy-boto3-inspector (>=1.35.0,<1.36.0)", "mypy-boto3-inspector-scan (>=1.35.0,<1.36.0)", "mypy-boto3-inspector2 (>=1.35.0,<1.36.0)", "mypy-boto3-internetmonitor (>=1.35.0,<1.36.0)", "mypy-boto3-iot (>=1.35.0,<1.36.0)", "mypy-boto3-iot-data (>=1.35.0,<1.36.0)", "mypy-boto3-iot-jobs-data (>=1.35.0,<1.36.0)", "mypy-boto3-iot1click-devices (>=1.35.0,<1.36.0)", "mypy-boto3-iot1click-projects (>=1.35.0,<1.36.0)", "mypy-boto3-iotanalytics (>=1.35.0,<1.36.0)", "mypy-boto3-iotdeviceadvisor (>=1.35.0,<1.36.0)", "mypy-boto3-iotevents (>=1.35.0,<1.36.0)", "mypy-boto3-iotevents-data (>=1.35.0,<1.36.0)", "mypy-boto3-iotfleethub (>=1.35.0,<1.36.0)", "mypy-boto3-iotfleetwise (>=1.35.0,<1.36.0)", "mypy-boto3-iotsecuretunneling (>=1.35.0,<1.36.0)", "mypy-boto3-iotsitewise (>=1.35.0,<1.36.0)", "mypy-boto3-iotthingsgraph (>=1.35.0,<1.36.0)", "mypy-boto3-iottwinmaker (>=1.35.0,<1.36.0)", "mypy-boto3-iotwireless (>=1.35.0,<1.36.0)", "mypy-boto3-ivs (>=1.35.0,<1.36.0)", "mypy-boto3-ivs-realtime (>=1.35.0,<1.36.0)", "mypy-boto3-ivschat (>=1.35.0,<1.36.0)", "mypy-boto3-kafka (>=1.35.0,<1.36.0)", "mypy-boto3-kafkaconnect (>=1.35.0,<1.36.0)", "mypy-boto3-kendra (>=1.35.0,<1.36.0)", "mypy-boto3-kendra-ranking (>=1.35.0,<1.36.0)", "mypy-boto3-keyspaces (>=1.35.0,<1.36.0)", "mypy-boto3-kinesis (>=1.35.0,<1.36.0)", "mypy-boto3-kinesis-video-archived-media (>=1.35.0,<1.36.0)", "mypy-boto3-kinesis-video-media (>=1.35.0,<1.36.0)", "mypy-boto3-kinesis-video-signaling (>=1.35.0,<1.36.0)", "mypy-boto3-kinesis-video-webrtc-storage (>=1.35.0,<1.36.0)", "mypy-boto3-kinesisanalytics (>=1.35.0,<1.36.0)", "mypy-boto3-kinesisanalyticsv2 (>=1.35.0,<1.36.0)", "mypy-boto3-kinesisvideo (>=1.35.0,<1.36.0)", "mypy-boto3-kms (>=1.35.0,<1.36.0)", "mypy-boto3-lakeformation (>=1.35.0,<1.36.0)", "mypy-boto3-lambda (>=1.35.0,<1.36.0)", "mypy-boto3-launch-wizard (>=1.35.0,<1.36.0)", "mypy-boto3-lex-models (>=1.35.0,<1.36.0)", "mypy-boto3-lex-runtime (>=1.35.0,<1.36.0)", "mypy-boto3-lexv2-models (>=1.35.0,<1.36.0)", "mypy-boto3-lexv2-runtime (>=1.35.0,<1.36.0)", "mypy-boto3-license-manager (>=1.35.0,<1.36.0)", "mypy-boto3-license-manager-linux-subscriptions (>=1.35.0,<1.36.0)", "mypy-boto3-license-manager-user-subscriptions (>=1.35.0,<1.36.0)", "mypy-boto3-lightsail (>=1.35.0,<1.36.0)", "mypy-boto3-location (>=1.35.0,<1.36.0)", "mypy-boto3-logs (>=1.35.0,<1.36.0)", "mypy-boto3-lookoutequipment (>=1.35.0,<1.36.0)", "mypy-boto3-lookoutmetrics (>=1.35.0,<1.36.0)", "mypy-boto3-lookoutvision (>=1.35.0,<1.36.0)", "mypy-boto3-m2 (>=1.35.0,<1.36.0)", "mypy-boto3-machinelearning (>=1.35.0,<1.36.0)", "mypy-boto3-macie2 (>=1.35.0,<1.36.0)", "mypy-boto3-mailmanager (>=1.35.0,<1.36.0)", "mypy-boto3-managedblockchain (>=1.35.0,<1.36.0)", "mypy-boto3-managedblockchain-query (>=1.35.0,<1.36.0)", "mypy-boto3-marketplace-agreement (>=1.35.0,<1.36.0)", "mypy-boto3-marketplace-catalog (>=1.35.0,<1.36.0)", "mypy-boto3-marketplace-deployment (>=1.35.0,<1.36.0)", "mypy-boto3-marketplace-entitlement (>=1.35.0,<1.36.0)", "mypy-boto3-marketplacecommerceanalytics (>=1.35.0,<1.36.0)", "mypy-boto3-mediaconnect (>=1.35.0,<1.36.0)", "mypy-boto3-mediaconvert (>=1.35.0,<1.36.0)", "mypy-boto3-medialive (>=1.35.0,<1.36.0)", "mypy-boto3-mediapackage (>=1.35.0,<1.36.0)", "mypy-boto3-mediapackage-vod (>=1.35.0,<1.36.0)", "mypy-boto3-mediapackagev2 (>=1.35.0,<1.36.0)", "mypy-boto3-mediastore (>=1.35.0,<1.36.0)", "mypy-boto3-mediastore-data (>=1.35.0,<1.36.0)", "mypy-boto3-mediatailor (>=1.35.0,<1.36.0)", "mypy-boto3-medical-imaging (>=1.35.0,<1.36.0)", "mypy-boto3-memorydb (>=1.35.0,<1.36.0)", "mypy-boto3-meteringmarketplace (>=1.35.0,<1.36.0)", "mypy-boto3-mgh (>=1.35.0,<1.36.0)", "mypy-boto3-mgn (>=1.35.0,<1.36.0)", "mypy-boto3-migration-hub-refactor-spaces (>=1.35.0,<1.36.0)", "mypy-boto3-migrationhub-config (>=1.35.0,<1.36.0)", "mypy-boto3-migrationhuborchestrator (>=1.35.0,<1.36.0)", "mypy-boto3-migrationhubstrategy (>=1.35.0,<1.36.0)", "mypy-boto3-mq (>=1.35.0,<1.36.0)", "mypy-boto3-mturk (>=1.35.0,<1.36.0)", "mypy-boto3-mwaa (>=1.35.0,<1.36.0)", "mypy-boto3-neptune (>=1.35.0,<1.36.0)", "mypy-boto3-neptune-graph (>=1.35.0,<1.36.0)", "mypy-boto3-neptunedata (>=1.35.0,<1.36.0)", "mypy-boto3-network-firewall (>=1.35.0,<1.36.0)", "mypy-boto3-networkmanager (>=1.35.0,<1.36.0)", "mypy-boto3-networkmonitor (>=1.35.0,<1.36.0)", "mypy-boto3-nimble (>=1.35.0,<1.36.0)", "mypy-boto3-oam (>=1.35.0,<1.36.0)", "mypy-boto3-omics (>=1.35.0,<1.36.0)", "mypy-boto3-opensearch (>=1.35.0,<1.36.0)", "mypy-boto3-opensearchserverless (>=1.35.0,<1.36.0)", "mypy-boto3-opsworks (>=1.35.0,<1.36.0)", "mypy-boto3-opsworkscm (>=1.35.0,<1.36.0)", "mypy-boto3-organizations (>=1.35.0,<1.36.0)", "mypy-boto3-osis (>=1.35.0,<1.36.0)", "mypy-boto3-outposts (>=1.35.0,<1.36.0)", "mypy-boto3-panorama (>=1.35.0,<1.36.0)", "mypy-boto3-payment-cryptography (>=1.35.0,<1.36.0)", "mypy-boto3-payment-cryptography-data (>=1.35.0,<1.36.0)", "mypy-boto3-pca-connector-ad (>=1.35.0,<1.36.0)", "mypy-boto3-pca-connector-scep (>=1.35.0,<1.36.0)", "mypy-boto3-pcs (>=1.35.0,<1.36.0)", "mypy-boto3-personalize (>=1.35.0,<1.36.0)", "mypy-boto3-personalize-events (>=1.35.0,<1.36.0)", "mypy-boto3-personalize-runtime (>=1.35.0,<1.36.0)", "mypy-boto3-pi (>=1.35.0,<1.36.0)", "mypy-boto3-pinpoint (>=1.35.0,<1.36.0)", "mypy-boto3-pinpoint-email (>=1.35.0,<1.36.0)", "mypy-boto3-pinpoint-sms-voice (>=1.35.0,<1.36.0)", "mypy-boto3-pinpoint-sms-voice-v2 (>=1.35.0,<1.36.0)", "mypy-boto3-pipes (>=1.35.0,<1.36.0)", "mypy-boto3-polly (>=1.35.0,<1.36.0)", "mypy-boto3-pricing (>=1.35.0,<1.36.0)", "mypy-boto3-privatenetworks (>=1.35.0,<1.36.0)", "mypy-boto3-proton (>=1.35.0,<1.36.0)", "mypy-boto3-qapps (>=1.35.0,<1.36.0)", "mypy-boto3-qbusiness (>=1.35.0,<1.36.0)", "mypy-boto3-qconnect (>=1.35.0,<1.36.0)", "mypy-boto3-qldb (>=1.35.0,<1.36.0)", "mypy-boto3-qldb-session (>=1.35.0,<1.36.0)", "mypy-boto3-quicksight (>=1.35.0,<1.36.0)", "mypy-boto3-ram (>=1.35.0,<1.36.0)", "mypy-boto3-rbin (>=1.35.0,<1.36.0)", "mypy-boto3-rds (>=1.35.0,<1.36.0)", "mypy-boto3-rds-data (>=1.35.0,<1.36.0)", "mypy-boto3-redshift (>=1.35.0,<1.36.0)", "mypy-boto3-redshift-data (>=1.35.0,<1.36.0)", "mypy-boto3-redshift-serverless (>=1.35.0,<1.36.0)", "mypy-boto3-rekognition (>=1.35.0,<1.36.0)", "mypy-boto3-repostspace (>=1.35.0,<1.36.0)", "mypy-boto3-resiliencehub (>=1.35.0,<1.36.0)", "mypy-boto3-resource-explorer-2 (>=1.35.0,<1.36.0)", "mypy-boto3-resource-groups (>=1.35.0,<1.36.0)", "mypy-boto3-resourcegroupstaggingapi (>=1.35.0,<1.36.0)", "mypy-boto3-robomaker (>=1.35.0,<1.36.0)", "mypy-boto3-rolesanywhere (>=1.35.0,<1.36.0)", "mypy-boto3-route53 (>=1.35.0,<1.36.0)", "mypy-boto3-route53-recovery-cluster (>=1.35.0,<1.36.0)", "mypy-boto3-route53-recovery-control-config (>=1.35.0,<1.36.0)", "mypy-boto3-route53-recovery-readiness (>=1.35.0,<1.36.0)", "mypy-boto3-route53domains (>=1.35.0,<1.36.0)", "mypy-boto3-route53profiles (>=1.35.0,<1.36.0)", "mypy-boto3-route53resolver (>=1.35.0,<1.36.0)", "mypy-boto3-rum (>=1.35.0,<1.36.0)", "mypy-boto3-s3 (>=1.35.0,<1.36.0)", "mypy-boto3-s3control (>=1.35.0,<1.36.0)", "mypy-boto3-s3outposts (>=1.35.0,<1.36.0)", "mypy-boto3-sagemaker (>=1.35.0,<1.36.0)", "mypy-boto3-sagemaker-a2i-runtime (>=1.35.0,<1.36.0)", "mypy-boto3-sagemaker-edge (>=1.35.0,<1.36.0)", "mypy-boto3-sagemaker-featurestore-runtime (>=1.35.0,<1.36.0)", "mypy-boto3-sagemaker-geospatial (>=1.35.0,<1.36.0)", "mypy-boto3-sagemaker-metrics (>=1.35.0,<1.36.0)", "mypy-boto3-sagemaker-runtime (>=1.35.0,<1.36.0)", "mypy-boto3-savingsplans (>=1.35.0,<1.36.0)", "mypy-boto3-scheduler (>=1.35.0,<1.36.0)", "mypy-boto3-schemas (>=1.35.0,<1.36.0)", "mypy-boto3-sdb (>=1.35.0,<1.36.0)", "mypy-boto3-secretsmanager (>=1.35.0,<1.36.0)", "mypy-boto3-securityhub (>=1.35.0,<1.36.0)", "mypy-boto3-securitylake (>=1.35.0,<1.36.0)", "mypy-boto3-serverlessrepo (>=1.35.0,<1.36.0)", "mypy-boto3-service-quotas (>=1.35.0,<1.36.0)", "mypy-boto3-servicecatalog (>=1.35.0,<1.36.0)", "mypy-boto3-servicecatalog-appregistry (>=1.35.0,<1.36.0)", "mypy-boto3-servicediscovery (>=1.35.0,<1.36.0)", "mypy-boto3-ses (>=1.35.0,<1.36.0)", "mypy-boto3-sesv2 (>=1.35.0,<1.36.0)", "mypy-boto3-shield (>=1.35.0,<1.36.0)", "mypy-boto3-signer (>=1.35.0,<1.36.0)", "mypy-boto3-simspaceweaver (>=1.35.0,<1.36.0)", "mypy-boto3-sms (>=1.35.0,<1.36.0)", "mypy-boto3-sms-voice (>=1.35.0,<1.36.0)", "mypy-boto3-snow-device-management (>=1.35.0,<1.36.0)", "mypy-boto3-snowball (>=1.35.0,<1.36.0)", "mypy-boto3-sns (>=1.35.0,<1.36.0)", "mypy-boto3-sqs (>=1.35.0,<1.36.0)", "mypy-boto3-ssm (>=1.35.0,<1.36.0)", "mypy-boto3-ssm-contacts (>=1.35.0,<1.36.0)", "mypy-boto3-ssm-incidents (>=1.35.0,<1.36.0)", "mypy-boto3-ssm-quicksetup (>=1.35.0,<1.36.0)", "mypy-boto3-ssm-sap (>=1.35.0,<1.36.0)", "mypy-boto3-sso (>=1.35.0,<1.36.0)", "mypy-boto3-sso-admin (>=1.35.0,<1.36.0)", "mypy-boto3-sso-oidc (>=1.35.0,<1.36.0)", "mypy-boto3-stepfunctions (>=1.35.0,<1.36.0)", "mypy-boto3-storagegateway (>=1.35.0,<1.36.0)", "mypy-boto3-sts (>=1.35.0,<1.36.0)", "mypy-boto3-supplychain (>=1.35.0,<1.36.0)", "mypy-boto3-support (>=1.35.0,<1.36.0)", "mypy-boto3-support-app (>=1.35.0,<1.36.0)", "mypy-boto3-swf (>=1.35.0,<1.36.0)", "mypy-boto3-synthetics (>=1.35.0,<1.36.0)", "mypy-boto3-taxsettings (>=1.35.0,<1.36.0)", "mypy-boto3-textract (>=1.35.0,<1.36.0)", "mypy-boto3-timestream-influxdb (>=1.35.0,<1.36.0)", "mypy-boto3-timestream-query (>=1.35.0,<1.36.0)", "mypy-boto3-timestream-write (>=1.35.0,<1.36.0)", "mypy-boto3-tnb (>=1.35.0,<1.36.0)", "mypy-boto3-transcribe (>=1.35.0,<1.36.0)", "mypy-boto3-transfer (>=1.35.0,<1.36.0)", "mypy-boto3-translate (>=1.35.0,<1.36.0)", "mypy-boto3-trustedadvisor (>=1.35.0,<1.36.0)", "mypy-boto3-verifiedpermissions (>=1.35.0,<1.36.0)", "mypy-boto3-voice-id (>=1.35.0,<1.36.0)", "mypy-boto3-vpc-lattice (>=1.35.0,<1.36.0)", "mypy-boto3-waf (>=1.35.0,<1.36.0)", "mypy-boto3-waf-regional (>=1.35.0,<1.36.0)", "mypy-boto3-wafv2 (>=1.35.0,<1.36.0)", "mypy-boto3-wellarchitected (>=1.35.0,<1.36.0)", "mypy-boto3-wisdom (>=1.35.0,<1.36.0)", "mypy-boto3-workdocs (>=1.35.0,<1.36.0)", "mypy-boto3-worklink (>=1.35.0,<1.36.0)", "mypy-boto3-workmail (>=1.35.0,<1.36.0)", "mypy-boto3-workmailmessageflow (>=1.35.0,<1.36.0)", "mypy-boto3-workspaces (>=1.35.0,<1.36.0)", "mypy-boto3-workspaces-thin-client (>=1.35.0,<1.36.0)", "mypy-boto3-workspaces-web (>=1.35.0,<1.36.0)", "mypy-boto3-xray (>=1.35.0,<1.36.0)"]
+amp = ["mypy-boto3-amp (>=1.35.0,<1.36.0)"]
+amplify = ["mypy-boto3-amplify (>=1.35.0,<1.36.0)"]
+amplifybackend = ["mypy-boto3-amplifybackend (>=1.35.0,<1.36.0)"]
+amplifyuibuilder = ["mypy-boto3-amplifyuibuilder (>=1.35.0,<1.36.0)"]
+apigateway = ["mypy-boto3-apigateway (>=1.35.0,<1.36.0)"]
+apigatewaymanagementapi = ["mypy-boto3-apigatewaymanagementapi (>=1.35.0,<1.36.0)"]
+apigatewayv2 = ["mypy-boto3-apigatewayv2 (>=1.35.0,<1.36.0)"]
+appconfig = ["mypy-boto3-appconfig (>=1.35.0,<1.36.0)"]
+appconfigdata = ["mypy-boto3-appconfigdata (>=1.35.0,<1.36.0)"]
+appfabric = ["mypy-boto3-appfabric (>=1.35.0,<1.36.0)"]
+appflow = ["mypy-boto3-appflow (>=1.35.0,<1.36.0)"]
+appintegrations = ["mypy-boto3-appintegrations (>=1.35.0,<1.36.0)"]
+application-autoscaling = ["mypy-boto3-application-autoscaling (>=1.35.0,<1.36.0)"]
+application-insights = ["mypy-boto3-application-insights (>=1.35.0,<1.36.0)"]
+application-signals = ["mypy-boto3-application-signals (>=1.35.0,<1.36.0)"]
+applicationcostprofiler = ["mypy-boto3-applicationcostprofiler (>=1.35.0,<1.36.0)"]
+appmesh = ["mypy-boto3-appmesh (>=1.35.0,<1.36.0)"]
+apprunner = ["mypy-boto3-apprunner (>=1.35.0,<1.36.0)"]
+appstream = ["mypy-boto3-appstream (>=1.35.0,<1.36.0)"]
+appsync = ["mypy-boto3-appsync (>=1.35.0,<1.36.0)"]
+apptest = ["mypy-boto3-apptest (>=1.35.0,<1.36.0)"]
+arc-zonal-shift = ["mypy-boto3-arc-zonal-shift (>=1.35.0,<1.36.0)"]
+artifact = ["mypy-boto3-artifact (>=1.35.0,<1.36.0)"]
+athena = ["mypy-boto3-athena (>=1.35.0,<1.36.0)"]
+auditmanager = ["mypy-boto3-auditmanager (>=1.35.0,<1.36.0)"]
+autoscaling = ["mypy-boto3-autoscaling (>=1.35.0,<1.36.0)"]
+autoscaling-plans = ["mypy-boto3-autoscaling-plans (>=1.35.0,<1.36.0)"]
+b2bi = ["mypy-boto3-b2bi (>=1.35.0,<1.36.0)"]
+backup = ["mypy-boto3-backup (>=1.35.0,<1.36.0)"]
+backup-gateway = ["mypy-boto3-backup-gateway (>=1.35.0,<1.36.0)"]
+batch = ["mypy-boto3-batch (>=1.35.0,<1.36.0)"]
+bcm-data-exports = ["mypy-boto3-bcm-data-exports (>=1.35.0,<1.36.0)"]
+bedrock = ["mypy-boto3-bedrock (>=1.35.0,<1.36.0)"]
+bedrock-agent = ["mypy-boto3-bedrock-agent (>=1.35.0,<1.36.0)"]
+bedrock-agent-runtime = ["mypy-boto3-bedrock-agent-runtime (>=1.35.0,<1.36.0)"]
+bedrock-runtime = ["mypy-boto3-bedrock-runtime (>=1.35.0,<1.36.0)"]
+billingconductor = ["mypy-boto3-billingconductor (>=1.35.0,<1.36.0)"]
+boto3 = ["boto3 (==1.35.13)", "botocore (==1.35.13)"]
+braket = ["mypy-boto3-braket (>=1.35.0,<1.36.0)"]
+budgets = ["mypy-boto3-budgets (>=1.35.0,<1.36.0)"]
+ce = ["mypy-boto3-ce (>=1.35.0,<1.36.0)"]
+chatbot = ["mypy-boto3-chatbot (>=1.35.0,<1.36.0)"]
+chime = ["mypy-boto3-chime (>=1.35.0,<1.36.0)"]
+chime-sdk-identity = ["mypy-boto3-chime-sdk-identity (>=1.35.0,<1.36.0)"]
+chime-sdk-media-pipelines = ["mypy-boto3-chime-sdk-media-pipelines (>=1.35.0,<1.36.0)"]
+chime-sdk-meetings = ["mypy-boto3-chime-sdk-meetings (>=1.35.0,<1.36.0)"]
+chime-sdk-messaging = ["mypy-boto3-chime-sdk-messaging (>=1.35.0,<1.36.0)"]
+chime-sdk-voice = ["mypy-boto3-chime-sdk-voice (>=1.35.0,<1.36.0)"]
+cleanrooms = ["mypy-boto3-cleanrooms (>=1.35.0,<1.36.0)"]
+cleanroomsml = ["mypy-boto3-cleanroomsml (>=1.35.0,<1.36.0)"]
+cloud9 = ["mypy-boto3-cloud9 (>=1.35.0,<1.36.0)"]
+cloudcontrol = ["mypy-boto3-cloudcontrol (>=1.35.0,<1.36.0)"]
+clouddirectory = ["mypy-boto3-clouddirectory (>=1.35.0,<1.36.0)"]
+cloudformation = ["mypy-boto3-cloudformation (>=1.35.0,<1.36.0)"]
+cloudfront = ["mypy-boto3-cloudfront (>=1.35.0,<1.36.0)"]
+cloudfront-keyvaluestore = ["mypy-boto3-cloudfront-keyvaluestore (>=1.35.0,<1.36.0)"]
+cloudhsm = ["mypy-boto3-cloudhsm (>=1.35.0,<1.36.0)"]
+cloudhsmv2 = ["mypy-boto3-cloudhsmv2 (>=1.35.0,<1.36.0)"]
+cloudsearch = ["mypy-boto3-cloudsearch (>=1.35.0,<1.36.0)"]
+cloudsearchdomain = ["mypy-boto3-cloudsearchdomain (>=1.35.0,<1.36.0)"]
+cloudtrail = ["mypy-boto3-cloudtrail (>=1.35.0,<1.36.0)"]
+cloudtrail-data = ["mypy-boto3-cloudtrail-data (>=1.35.0,<1.36.0)"]
+cloudwatch = ["mypy-boto3-cloudwatch (>=1.35.0,<1.36.0)"]
+codeartifact = ["mypy-boto3-codeartifact (>=1.35.0,<1.36.0)"]
+codebuild = ["mypy-boto3-codebuild (>=1.35.0,<1.36.0)"]
+codecatalyst = ["mypy-boto3-codecatalyst (>=1.35.0,<1.36.0)"]
+codecommit = ["mypy-boto3-codecommit (>=1.35.0,<1.36.0)"]
+codeconnections = ["mypy-boto3-codeconnections (>=1.35.0,<1.36.0)"]
+codedeploy = ["mypy-boto3-codedeploy (>=1.35.0,<1.36.0)"]
+codeguru-reviewer = ["mypy-boto3-codeguru-reviewer (>=1.35.0,<1.36.0)"]
+codeguru-security = ["mypy-boto3-codeguru-security (>=1.35.0,<1.36.0)"]
+codeguruprofiler = ["mypy-boto3-codeguruprofiler (>=1.35.0,<1.36.0)"]
+codepipeline = ["mypy-boto3-codepipeline (>=1.35.0,<1.36.0)"]
+codestar-connections = ["mypy-boto3-codestar-connections (>=1.35.0,<1.36.0)"]
+codestar-notifications = ["mypy-boto3-codestar-notifications (>=1.35.0,<1.36.0)"]
+cognito-identity = ["mypy-boto3-cognito-identity (>=1.35.0,<1.36.0)"]
+cognito-idp = ["mypy-boto3-cognito-idp (>=1.35.0,<1.36.0)"]
+cognito-sync = ["mypy-boto3-cognito-sync (>=1.35.0,<1.36.0)"]
+comprehend = ["mypy-boto3-comprehend (>=1.35.0,<1.36.0)"]
+comprehendmedical = ["mypy-boto3-comprehendmedical (>=1.35.0,<1.36.0)"]
+compute-optimizer = ["mypy-boto3-compute-optimizer (>=1.35.0,<1.36.0)"]
+config = ["mypy-boto3-config (>=1.35.0,<1.36.0)"]
+connect = ["mypy-boto3-connect (>=1.35.0,<1.36.0)"]
+connect-contact-lens = ["mypy-boto3-connect-contact-lens (>=1.35.0,<1.36.0)"]
+connectcampaigns = ["mypy-boto3-connectcampaigns (>=1.35.0,<1.36.0)"]
+connectcases = ["mypy-boto3-connectcases (>=1.35.0,<1.36.0)"]
+connectparticipant = ["mypy-boto3-connectparticipant (>=1.35.0,<1.36.0)"]
+controlcatalog = ["mypy-boto3-controlcatalog (>=1.35.0,<1.36.0)"]
+controltower = ["mypy-boto3-controltower (>=1.35.0,<1.36.0)"]
+cost-optimization-hub = ["mypy-boto3-cost-optimization-hub (>=1.35.0,<1.36.0)"]
+cur = ["mypy-boto3-cur (>=1.35.0,<1.36.0)"]
+customer-profiles = ["mypy-boto3-customer-profiles (>=1.35.0,<1.36.0)"]
+databrew = ["mypy-boto3-databrew (>=1.35.0,<1.36.0)"]
+dataexchange = ["mypy-boto3-dataexchange (>=1.35.0,<1.36.0)"]
+datapipeline = ["mypy-boto3-datapipeline (>=1.35.0,<1.36.0)"]
+datasync = ["mypy-boto3-datasync (>=1.35.0,<1.36.0)"]
+datazone = ["mypy-boto3-datazone (>=1.35.0,<1.36.0)"]
+dax = ["mypy-boto3-dax (>=1.35.0,<1.36.0)"]
+deadline = ["mypy-boto3-deadline (>=1.35.0,<1.36.0)"]
+detective = ["mypy-boto3-detective (>=1.35.0,<1.36.0)"]
+devicefarm = ["mypy-boto3-devicefarm (>=1.35.0,<1.36.0)"]
+devops-guru = ["mypy-boto3-devops-guru (>=1.35.0,<1.36.0)"]
+directconnect = ["mypy-boto3-directconnect (>=1.35.0,<1.36.0)"]
+discovery = ["mypy-boto3-discovery (>=1.35.0,<1.36.0)"]
+dlm = ["mypy-boto3-dlm (>=1.35.0,<1.36.0)"]
+dms = ["mypy-boto3-dms (>=1.35.0,<1.36.0)"]
+docdb = ["mypy-boto3-docdb (>=1.35.0,<1.36.0)"]
+docdb-elastic = ["mypy-boto3-docdb-elastic (>=1.35.0,<1.36.0)"]
+drs = ["mypy-boto3-drs (>=1.35.0,<1.36.0)"]
+ds = ["mypy-boto3-ds (>=1.35.0,<1.36.0)"]
+dynamodb = ["mypy-boto3-dynamodb (>=1.35.0,<1.36.0)"]
+dynamodbstreams = ["mypy-boto3-dynamodbstreams (>=1.35.0,<1.36.0)"]
+ebs = ["mypy-boto3-ebs (>=1.35.0,<1.36.0)"]
+ec2 = ["mypy-boto3-ec2 (>=1.35.0,<1.36.0)"]
+ec2-instance-connect = ["mypy-boto3-ec2-instance-connect (>=1.35.0,<1.36.0)"]
+ecr = ["mypy-boto3-ecr (>=1.35.0,<1.36.0)"]
+ecr-public = ["mypy-boto3-ecr-public (>=1.35.0,<1.36.0)"]
+ecs = ["mypy-boto3-ecs (>=1.35.0,<1.36.0)"]
+efs = ["mypy-boto3-efs (>=1.35.0,<1.36.0)"]
+eks = ["mypy-boto3-eks (>=1.35.0,<1.36.0)"]
+eks-auth = ["mypy-boto3-eks-auth (>=1.35.0,<1.36.0)"]
+elastic-inference = ["mypy-boto3-elastic-inference (>=1.35.0,<1.36.0)"]
+elasticache = ["mypy-boto3-elasticache (>=1.35.0,<1.36.0)"]
+elasticbeanstalk = ["mypy-boto3-elasticbeanstalk (>=1.35.0,<1.36.0)"]
+elastictranscoder = ["mypy-boto3-elastictranscoder (>=1.35.0,<1.36.0)"]
+elb = ["mypy-boto3-elb (>=1.35.0,<1.36.0)"]
+elbv2 = ["mypy-boto3-elbv2 (>=1.35.0,<1.36.0)"]
+emr = ["mypy-boto3-emr (>=1.35.0,<1.36.0)"]
+emr-containers = ["mypy-boto3-emr-containers (>=1.35.0,<1.36.0)"]
+emr-serverless = ["mypy-boto3-emr-serverless (>=1.35.0,<1.36.0)"]
+entityresolution = ["mypy-boto3-entityresolution (>=1.35.0,<1.36.0)"]
+es = ["mypy-boto3-es (>=1.35.0,<1.36.0)"]
+essential = ["mypy-boto3-cloudformation (>=1.35.0,<1.36.0)", "mypy-boto3-dynamodb (>=1.35.0,<1.36.0)", "mypy-boto3-ec2 (>=1.35.0,<1.36.0)", "mypy-boto3-lambda (>=1.35.0,<1.36.0)", "mypy-boto3-rds (>=1.35.0,<1.36.0)", "mypy-boto3-s3 (>=1.35.0,<1.36.0)", "mypy-boto3-sqs (>=1.35.0,<1.36.0)"]
+events = ["mypy-boto3-events (>=1.35.0,<1.36.0)"]
+evidently = ["mypy-boto3-evidently (>=1.35.0,<1.36.0)"]
+finspace = ["mypy-boto3-finspace (>=1.35.0,<1.36.0)"]
+finspace-data = ["mypy-boto3-finspace-data (>=1.35.0,<1.36.0)"]
+firehose = ["mypy-boto3-firehose (>=1.35.0,<1.36.0)"]
+fis = ["mypy-boto3-fis (>=1.35.0,<1.36.0)"]
+fms = ["mypy-boto3-fms (>=1.35.0,<1.36.0)"]
+forecast = ["mypy-boto3-forecast (>=1.35.0,<1.36.0)"]
+forecastquery = ["mypy-boto3-forecastquery (>=1.35.0,<1.36.0)"]
+frauddetector = ["mypy-boto3-frauddetector (>=1.35.0,<1.36.0)"]
+freetier = ["mypy-boto3-freetier (>=1.35.0,<1.36.0)"]
+fsx = ["mypy-boto3-fsx (>=1.35.0,<1.36.0)"]
+full = ["boto3-stubs-full"]
+gamelift = ["mypy-boto3-gamelift (>=1.35.0,<1.36.0)"]
+glacier = ["mypy-boto3-glacier (>=1.35.0,<1.36.0)"]
+globalaccelerator = ["mypy-boto3-globalaccelerator (>=1.35.0,<1.36.0)"]
+glue = ["mypy-boto3-glue (>=1.35.0,<1.36.0)"]
+grafana = ["mypy-boto3-grafana (>=1.35.0,<1.36.0)"]
+greengrass = ["mypy-boto3-greengrass (>=1.35.0,<1.36.0)"]
+greengrassv2 = ["mypy-boto3-greengrassv2 (>=1.35.0,<1.36.0)"]
+groundstation = ["mypy-boto3-groundstation (>=1.35.0,<1.36.0)"]
+guardduty = ["mypy-boto3-guardduty (>=1.35.0,<1.36.0)"]
+health = ["mypy-boto3-health (>=1.35.0,<1.36.0)"]
+healthlake = ["mypy-boto3-healthlake (>=1.35.0,<1.36.0)"]
+iam = ["mypy-boto3-iam (>=1.35.0,<1.36.0)"]
+identitystore = ["mypy-boto3-identitystore (>=1.35.0,<1.36.0)"]
+imagebuilder = ["mypy-boto3-imagebuilder (>=1.35.0,<1.36.0)"]
+importexport = ["mypy-boto3-importexport (>=1.35.0,<1.36.0)"]
+inspector = ["mypy-boto3-inspector (>=1.35.0,<1.36.0)"]
+inspector-scan = ["mypy-boto3-inspector-scan (>=1.35.0,<1.36.0)"]
+inspector2 = ["mypy-boto3-inspector2 (>=1.35.0,<1.36.0)"]
+internetmonitor = ["mypy-boto3-internetmonitor (>=1.35.0,<1.36.0)"]
+iot = ["mypy-boto3-iot (>=1.35.0,<1.36.0)"]
+iot-data = ["mypy-boto3-iot-data (>=1.35.0,<1.36.0)"]
+iot-jobs-data = ["mypy-boto3-iot-jobs-data (>=1.35.0,<1.36.0)"]
+iot1click-devices = ["mypy-boto3-iot1click-devices (>=1.35.0,<1.36.0)"]
+iot1click-projects = ["mypy-boto3-iot1click-projects (>=1.35.0,<1.36.0)"]
+iotanalytics = ["mypy-boto3-iotanalytics (>=1.35.0,<1.36.0)"]
+iotdeviceadvisor = ["mypy-boto3-iotdeviceadvisor (>=1.35.0,<1.36.0)"]
+iotevents = ["mypy-boto3-iotevents (>=1.35.0,<1.36.0)"]
+iotevents-data = ["mypy-boto3-iotevents-data (>=1.35.0,<1.36.0)"]
+iotfleethub = ["mypy-boto3-iotfleethub (>=1.35.0,<1.36.0)"]
+iotfleetwise = ["mypy-boto3-iotfleetwise (>=1.35.0,<1.36.0)"]
+iotsecuretunneling = ["mypy-boto3-iotsecuretunneling (>=1.35.0,<1.36.0)"]
+iotsitewise = ["mypy-boto3-iotsitewise (>=1.35.0,<1.36.0)"]
+iotthingsgraph = ["mypy-boto3-iotthingsgraph (>=1.35.0,<1.36.0)"]
+iottwinmaker = ["mypy-boto3-iottwinmaker (>=1.35.0,<1.36.0)"]
+iotwireless = ["mypy-boto3-iotwireless (>=1.35.0,<1.36.0)"]
+ivs = ["mypy-boto3-ivs (>=1.35.0,<1.36.0)"]
+ivs-realtime = ["mypy-boto3-ivs-realtime (>=1.35.0,<1.36.0)"]
+ivschat = ["mypy-boto3-ivschat (>=1.35.0,<1.36.0)"]
+kafka = ["mypy-boto3-kafka (>=1.35.0,<1.36.0)"]
+kafkaconnect = ["mypy-boto3-kafkaconnect (>=1.35.0,<1.36.0)"]
+kendra = ["mypy-boto3-kendra (>=1.35.0,<1.36.0)"]
+kendra-ranking = ["mypy-boto3-kendra-ranking (>=1.35.0,<1.36.0)"]
+keyspaces = ["mypy-boto3-keyspaces (>=1.35.0,<1.36.0)"]
+kinesis = ["mypy-boto3-kinesis (>=1.35.0,<1.36.0)"]
+kinesis-video-archived-media = ["mypy-boto3-kinesis-video-archived-media (>=1.35.0,<1.36.0)"]
+kinesis-video-media = ["mypy-boto3-kinesis-video-media (>=1.35.0,<1.36.0)"]
+kinesis-video-signaling = ["mypy-boto3-kinesis-video-signaling (>=1.35.0,<1.36.0)"]
+kinesis-video-webrtc-storage = ["mypy-boto3-kinesis-video-webrtc-storage (>=1.35.0,<1.36.0)"]
+kinesisanalytics = ["mypy-boto3-kinesisanalytics (>=1.35.0,<1.36.0)"]
+kinesisanalyticsv2 = ["mypy-boto3-kinesisanalyticsv2 (>=1.35.0,<1.36.0)"]
+kinesisvideo = ["mypy-boto3-kinesisvideo (>=1.35.0,<1.36.0)"]
+kms = ["mypy-boto3-kms (>=1.35.0,<1.36.0)"]
+lakeformation = ["mypy-boto3-lakeformation (>=1.35.0,<1.36.0)"]
+lambda = ["mypy-boto3-lambda (>=1.35.0,<1.36.0)"]
+launch-wizard = ["mypy-boto3-launch-wizard (>=1.35.0,<1.36.0)"]
+lex-models = ["mypy-boto3-lex-models (>=1.35.0,<1.36.0)"]
+lex-runtime = ["mypy-boto3-lex-runtime (>=1.35.0,<1.36.0)"]
+lexv2-models = ["mypy-boto3-lexv2-models (>=1.35.0,<1.36.0)"]
+lexv2-runtime = ["mypy-boto3-lexv2-runtime (>=1.35.0,<1.36.0)"]
+license-manager = ["mypy-boto3-license-manager (>=1.35.0,<1.36.0)"]
+license-manager-linux-subscriptions = ["mypy-boto3-license-manager-linux-subscriptions (>=1.35.0,<1.36.0)"]
+license-manager-user-subscriptions = ["mypy-boto3-license-manager-user-subscriptions (>=1.35.0,<1.36.0)"]
+lightsail = ["mypy-boto3-lightsail (>=1.35.0,<1.36.0)"]
+location = ["mypy-boto3-location (>=1.35.0,<1.36.0)"]
+logs = ["mypy-boto3-logs (>=1.35.0,<1.36.0)"]
+lookoutequipment = ["mypy-boto3-lookoutequipment (>=1.35.0,<1.36.0)"]
+lookoutmetrics = ["mypy-boto3-lookoutmetrics (>=1.35.0,<1.36.0)"]
+lookoutvision = ["mypy-boto3-lookoutvision (>=1.35.0,<1.36.0)"]
+m2 = ["mypy-boto3-m2 (>=1.35.0,<1.36.0)"]
+machinelearning = ["mypy-boto3-machinelearning (>=1.35.0,<1.36.0)"]
+macie2 = ["mypy-boto3-macie2 (>=1.35.0,<1.36.0)"]
+mailmanager = ["mypy-boto3-mailmanager (>=1.35.0,<1.36.0)"]
+managedblockchain = ["mypy-boto3-managedblockchain (>=1.35.0,<1.36.0)"]
+managedblockchain-query = ["mypy-boto3-managedblockchain-query (>=1.35.0,<1.36.0)"]
+marketplace-agreement = ["mypy-boto3-marketplace-agreement (>=1.35.0,<1.36.0)"]
+marketplace-catalog = ["mypy-boto3-marketplace-catalog (>=1.35.0,<1.36.0)"]
+marketplace-deployment = ["mypy-boto3-marketplace-deployment (>=1.35.0,<1.36.0)"]
+marketplace-entitlement = ["mypy-boto3-marketplace-entitlement (>=1.35.0,<1.36.0)"]
+marketplacecommerceanalytics = ["mypy-boto3-marketplacecommerceanalytics (>=1.35.0,<1.36.0)"]
+mediaconnect = ["mypy-boto3-mediaconnect (>=1.35.0,<1.36.0)"]
+mediaconvert = ["mypy-boto3-mediaconvert (>=1.35.0,<1.36.0)"]
+medialive = ["mypy-boto3-medialive (>=1.35.0,<1.36.0)"]
+mediapackage = ["mypy-boto3-mediapackage (>=1.35.0,<1.36.0)"]
+mediapackage-vod = ["mypy-boto3-mediapackage-vod (>=1.35.0,<1.36.0)"]
+mediapackagev2 = ["mypy-boto3-mediapackagev2 (>=1.35.0,<1.36.0)"]
+mediastore = ["mypy-boto3-mediastore (>=1.35.0,<1.36.0)"]
+mediastore-data = ["mypy-boto3-mediastore-data (>=1.35.0,<1.36.0)"]
+mediatailor = ["mypy-boto3-mediatailor (>=1.35.0,<1.36.0)"]
+medical-imaging = ["mypy-boto3-medical-imaging (>=1.35.0,<1.36.0)"]
+memorydb = ["mypy-boto3-memorydb (>=1.35.0,<1.36.0)"]
+meteringmarketplace = ["mypy-boto3-meteringmarketplace (>=1.35.0,<1.36.0)"]
+mgh = ["mypy-boto3-mgh (>=1.35.0,<1.36.0)"]
+mgn = ["mypy-boto3-mgn (>=1.35.0,<1.36.0)"]
+migration-hub-refactor-spaces = ["mypy-boto3-migration-hub-refactor-spaces (>=1.35.0,<1.36.0)"]
+migrationhub-config = ["mypy-boto3-migrationhub-config (>=1.35.0,<1.36.0)"]
+migrationhuborchestrator = ["mypy-boto3-migrationhuborchestrator (>=1.35.0,<1.36.0)"]
+migrationhubstrategy = ["mypy-boto3-migrationhubstrategy (>=1.35.0,<1.36.0)"]
+mq = ["mypy-boto3-mq (>=1.35.0,<1.36.0)"]
+mturk = ["mypy-boto3-mturk (>=1.35.0,<1.36.0)"]
+mwaa = ["mypy-boto3-mwaa (>=1.35.0,<1.36.0)"]
+neptune = ["mypy-boto3-neptune (>=1.35.0,<1.36.0)"]
+neptune-graph = ["mypy-boto3-neptune-graph (>=1.35.0,<1.36.0)"]
+neptunedata = ["mypy-boto3-neptunedata (>=1.35.0,<1.36.0)"]
+network-firewall = ["mypy-boto3-network-firewall (>=1.35.0,<1.36.0)"]
+networkmanager = ["mypy-boto3-networkmanager (>=1.35.0,<1.36.0)"]
+networkmonitor = ["mypy-boto3-networkmonitor (>=1.35.0,<1.36.0)"]
+nimble = ["mypy-boto3-nimble (>=1.35.0,<1.36.0)"]
+oam = ["mypy-boto3-oam (>=1.35.0,<1.36.0)"]
+omics = ["mypy-boto3-omics (>=1.35.0,<1.36.0)"]
+opensearch = ["mypy-boto3-opensearch (>=1.35.0,<1.36.0)"]
+opensearchserverless = ["mypy-boto3-opensearchserverless (>=1.35.0,<1.36.0)"]
+opsworks = ["mypy-boto3-opsworks (>=1.35.0,<1.36.0)"]
+opsworkscm = ["mypy-boto3-opsworkscm (>=1.35.0,<1.36.0)"]
+organizations = ["mypy-boto3-organizations (>=1.35.0,<1.36.0)"]
+osis = ["mypy-boto3-osis (>=1.35.0,<1.36.0)"]
+outposts = ["mypy-boto3-outposts (>=1.35.0,<1.36.0)"]
+panorama = ["mypy-boto3-panorama (>=1.35.0,<1.36.0)"]
+payment-cryptography = ["mypy-boto3-payment-cryptography (>=1.35.0,<1.36.0)"]
+payment-cryptography-data = ["mypy-boto3-payment-cryptography-data (>=1.35.0,<1.36.0)"]
+pca-connector-ad = ["mypy-boto3-pca-connector-ad (>=1.35.0,<1.36.0)"]
+pca-connector-scep = ["mypy-boto3-pca-connector-scep (>=1.35.0,<1.36.0)"]
+pcs = ["mypy-boto3-pcs (>=1.35.0,<1.36.0)"]
+personalize = ["mypy-boto3-personalize (>=1.35.0,<1.36.0)"]
+personalize-events = ["mypy-boto3-personalize-events (>=1.35.0,<1.36.0)"]
+personalize-runtime = ["mypy-boto3-personalize-runtime (>=1.35.0,<1.36.0)"]
+pi = ["mypy-boto3-pi (>=1.35.0,<1.36.0)"]
+pinpoint = ["mypy-boto3-pinpoint (>=1.35.0,<1.36.0)"]
+pinpoint-email = ["mypy-boto3-pinpoint-email (>=1.35.0,<1.36.0)"]
+pinpoint-sms-voice = ["mypy-boto3-pinpoint-sms-voice (>=1.35.0,<1.36.0)"]
+pinpoint-sms-voice-v2 = ["mypy-boto3-pinpoint-sms-voice-v2 (>=1.35.0,<1.36.0)"]
+pipes = ["mypy-boto3-pipes (>=1.35.0,<1.36.0)"]
+polly = ["mypy-boto3-polly (>=1.35.0,<1.36.0)"]
+pricing = ["mypy-boto3-pricing (>=1.35.0,<1.36.0)"]
+privatenetworks = ["mypy-boto3-privatenetworks (>=1.35.0,<1.36.0)"]
+proton = ["mypy-boto3-proton (>=1.35.0,<1.36.0)"]
+qapps = ["mypy-boto3-qapps (>=1.35.0,<1.36.0)"]
+qbusiness = ["mypy-boto3-qbusiness (>=1.35.0,<1.36.0)"]
+qconnect = ["mypy-boto3-qconnect (>=1.35.0,<1.36.0)"]
+qldb = ["mypy-boto3-qldb (>=1.35.0,<1.36.0)"]
+qldb-session = ["mypy-boto3-qldb-session (>=1.35.0,<1.36.0)"]
+quicksight = ["mypy-boto3-quicksight (>=1.35.0,<1.36.0)"]
+ram = ["mypy-boto3-ram (>=1.35.0,<1.36.0)"]
+rbin = ["mypy-boto3-rbin (>=1.35.0,<1.36.0)"]
+rds = ["mypy-boto3-rds (>=1.35.0,<1.36.0)"]
+rds-data = ["mypy-boto3-rds-data (>=1.35.0,<1.36.0)"]
+redshift = ["mypy-boto3-redshift (>=1.35.0,<1.36.0)"]
+redshift-data = ["mypy-boto3-redshift-data (>=1.35.0,<1.36.0)"]
+redshift-serverless = ["mypy-boto3-redshift-serverless (>=1.35.0,<1.36.0)"]
+rekognition = ["mypy-boto3-rekognition (>=1.35.0,<1.36.0)"]
+repostspace = ["mypy-boto3-repostspace (>=1.35.0,<1.36.0)"]
+resiliencehub = ["mypy-boto3-resiliencehub (>=1.35.0,<1.36.0)"]
+resource-explorer-2 = ["mypy-boto3-resource-explorer-2 (>=1.35.0,<1.36.0)"]
+resource-groups = ["mypy-boto3-resource-groups (>=1.35.0,<1.36.0)"]
+resourcegroupstaggingapi = ["mypy-boto3-resourcegroupstaggingapi (>=1.35.0,<1.36.0)"]
+robomaker = ["mypy-boto3-robomaker (>=1.35.0,<1.36.0)"]
+rolesanywhere = ["mypy-boto3-rolesanywhere (>=1.35.0,<1.36.0)"]
+route53 = ["mypy-boto3-route53 (>=1.35.0,<1.36.0)"]
+route53-recovery-cluster = ["mypy-boto3-route53-recovery-cluster (>=1.35.0,<1.36.0)"]
+route53-recovery-control-config = ["mypy-boto3-route53-recovery-control-config (>=1.35.0,<1.36.0)"]
+route53-recovery-readiness = ["mypy-boto3-route53-recovery-readiness (>=1.35.0,<1.36.0)"]
+route53domains = ["mypy-boto3-route53domains (>=1.35.0,<1.36.0)"]
+route53profiles = ["mypy-boto3-route53profiles (>=1.35.0,<1.36.0)"]
+route53resolver = ["mypy-boto3-route53resolver (>=1.35.0,<1.36.0)"]
+rum = ["mypy-boto3-rum (>=1.35.0,<1.36.0)"]
+s3 = ["mypy-boto3-s3 (>=1.35.0,<1.36.0)"]
+s3control = ["mypy-boto3-s3control (>=1.35.0,<1.36.0)"]
+s3outposts = ["mypy-boto3-s3outposts (>=1.35.0,<1.36.0)"]
+sagemaker = ["mypy-boto3-sagemaker (>=1.35.0,<1.36.0)"]
+sagemaker-a2i-runtime = ["mypy-boto3-sagemaker-a2i-runtime (>=1.35.0,<1.36.0)"]
+sagemaker-edge = ["mypy-boto3-sagemaker-edge (>=1.35.0,<1.36.0)"]
+sagemaker-featurestore-runtime = ["mypy-boto3-sagemaker-featurestore-runtime (>=1.35.0,<1.36.0)"]
+sagemaker-geospatial = ["mypy-boto3-sagemaker-geospatial (>=1.35.0,<1.36.0)"]
+sagemaker-metrics = ["mypy-boto3-sagemaker-metrics (>=1.35.0,<1.36.0)"]
+sagemaker-runtime = ["mypy-boto3-sagemaker-runtime (>=1.35.0,<1.36.0)"]
+savingsplans = ["mypy-boto3-savingsplans (>=1.35.0,<1.36.0)"]
+scheduler = ["mypy-boto3-scheduler (>=1.35.0,<1.36.0)"]
+schemas = ["mypy-boto3-schemas (>=1.35.0,<1.36.0)"]
+sdb = ["mypy-boto3-sdb (>=1.35.0,<1.36.0)"]
+secretsmanager = ["mypy-boto3-secretsmanager (>=1.35.0,<1.36.0)"]
+securityhub = ["mypy-boto3-securityhub (>=1.35.0,<1.36.0)"]
+securitylake = ["mypy-boto3-securitylake (>=1.35.0,<1.36.0)"]
+serverlessrepo = ["mypy-boto3-serverlessrepo (>=1.35.0,<1.36.0)"]
+service-quotas = ["mypy-boto3-service-quotas (>=1.35.0,<1.36.0)"]
+servicecatalog = ["mypy-boto3-servicecatalog (>=1.35.0,<1.36.0)"]
+servicecatalog-appregistry = ["mypy-boto3-servicecatalog-appregistry (>=1.35.0,<1.36.0)"]
+servicediscovery = ["mypy-boto3-servicediscovery (>=1.35.0,<1.36.0)"]
+ses = ["mypy-boto3-ses (>=1.35.0,<1.36.0)"]
+sesv2 = ["mypy-boto3-sesv2 (>=1.35.0,<1.36.0)"]
+shield = ["mypy-boto3-shield (>=1.35.0,<1.36.0)"]
+signer = ["mypy-boto3-signer (>=1.35.0,<1.36.0)"]
+simspaceweaver = ["mypy-boto3-simspaceweaver (>=1.35.0,<1.36.0)"]
+sms = ["mypy-boto3-sms (>=1.35.0,<1.36.0)"]
+sms-voice = ["mypy-boto3-sms-voice (>=1.35.0,<1.36.0)"]
+snow-device-management = ["mypy-boto3-snow-device-management (>=1.35.0,<1.36.0)"]
+snowball = ["mypy-boto3-snowball (>=1.35.0,<1.36.0)"]
+sns = ["mypy-boto3-sns (>=1.35.0,<1.36.0)"]
+sqs = ["mypy-boto3-sqs (>=1.35.0,<1.36.0)"]
+ssm = ["mypy-boto3-ssm (>=1.35.0,<1.36.0)"]
+ssm-contacts = ["mypy-boto3-ssm-contacts (>=1.35.0,<1.36.0)"]
+ssm-incidents = ["mypy-boto3-ssm-incidents (>=1.35.0,<1.36.0)"]
+ssm-quicksetup = ["mypy-boto3-ssm-quicksetup (>=1.35.0,<1.36.0)"]
+ssm-sap = ["mypy-boto3-ssm-sap (>=1.35.0,<1.36.0)"]
+sso = ["mypy-boto3-sso (>=1.35.0,<1.36.0)"]
+sso-admin = ["mypy-boto3-sso-admin (>=1.35.0,<1.36.0)"]
+sso-oidc = ["mypy-boto3-sso-oidc (>=1.35.0,<1.36.0)"]
+stepfunctions = ["mypy-boto3-stepfunctions (>=1.35.0,<1.36.0)"]
+storagegateway = ["mypy-boto3-storagegateway (>=1.35.0,<1.36.0)"]
+sts = ["mypy-boto3-sts (>=1.35.0,<1.36.0)"]
+supplychain = ["mypy-boto3-supplychain (>=1.35.0,<1.36.0)"]
+support = ["mypy-boto3-support (>=1.35.0,<1.36.0)"]
+support-app = ["mypy-boto3-support-app (>=1.35.0,<1.36.0)"]
+swf = ["mypy-boto3-swf (>=1.35.0,<1.36.0)"]
+synthetics = ["mypy-boto3-synthetics (>=1.35.0,<1.36.0)"]
+taxsettings = ["mypy-boto3-taxsettings (>=1.35.0,<1.36.0)"]
+textract = ["mypy-boto3-textract (>=1.35.0,<1.36.0)"]
+timestream-influxdb = ["mypy-boto3-timestream-influxdb (>=1.35.0,<1.36.0)"]
+timestream-query = ["mypy-boto3-timestream-query (>=1.35.0,<1.36.0)"]
+timestream-write = ["mypy-boto3-timestream-write (>=1.35.0,<1.36.0)"]
+tnb = ["mypy-boto3-tnb (>=1.35.0,<1.36.0)"]
+transcribe = ["mypy-boto3-transcribe (>=1.35.0,<1.36.0)"]
+transfer = ["mypy-boto3-transfer (>=1.35.0,<1.36.0)"]
+translate = ["mypy-boto3-translate (>=1.35.0,<1.36.0)"]
+trustedadvisor = ["mypy-boto3-trustedadvisor (>=1.35.0,<1.36.0)"]
+verifiedpermissions = ["mypy-boto3-verifiedpermissions (>=1.35.0,<1.36.0)"]
+voice-id = ["mypy-boto3-voice-id (>=1.35.0,<1.36.0)"]
+vpc-lattice = ["mypy-boto3-vpc-lattice (>=1.35.0,<1.36.0)"]
+waf = ["mypy-boto3-waf (>=1.35.0,<1.36.0)"]
+waf-regional = ["mypy-boto3-waf-regional (>=1.35.0,<1.36.0)"]
+wafv2 = ["mypy-boto3-wafv2 (>=1.35.0,<1.36.0)"]
+wellarchitected = ["mypy-boto3-wellarchitected (>=1.35.0,<1.36.0)"]
+wisdom = ["mypy-boto3-wisdom (>=1.35.0,<1.36.0)"]
+workdocs = ["mypy-boto3-workdocs (>=1.35.0,<1.36.0)"]
+worklink = ["mypy-boto3-worklink (>=1.35.0,<1.36.0)"]
+workmail = ["mypy-boto3-workmail (>=1.35.0,<1.36.0)"]
+workmailmessageflow = ["mypy-boto3-workmailmessageflow (>=1.35.0,<1.36.0)"]
+workspaces = ["mypy-boto3-workspaces (>=1.35.0,<1.36.0)"]
+workspaces-thin-client = ["mypy-boto3-workspaces-thin-client (>=1.35.0,<1.36.0)"]
+workspaces-web = ["mypy-boto3-workspaces-web (>=1.35.0,<1.36.0)"]
+xray = ["mypy-boto3-xray (>=1.35.0,<1.36.0)"]
+
+[[package]]
 name = "botocore"
 version = "1.35.9"
 description = "Low-level, data-driven core of boto 3."
@@ -114,6 +525,23 @@ urllib3 = {version = ">=1.25.4,<2.2.0 || >2.2.0,<3", markers = "python_version >
 
 [package.extras]
 crt = ["awscrt (==0.21.2)"]
+
+[[package]]
+name = "botocore-stubs"
+version = "1.35.13"
+description = "Type annotations and code completion for botocore"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "botocore_stubs-1.35.13-py3-none-any.whl", hash = "sha256:5a0f68e9aeebfbce5a2be80302974b450f022ccedd073deb366cb278b74b8612"},
+    {file = "botocore_stubs-1.35.13.tar.gz", hash = "sha256:755a818b016658b410e4c52cb135953d09fd1db086c829ed87c367971d7084da"},
+]
+
+[package.dependencies]
+types-awscrt = "*"
+
+[package.extras]
+botocore = ["botocore"]
 
 [[package]]
 name = "bpython"
@@ -1195,6 +1623,48 @@ mypyc = ["setuptools (>=50)"]
 reports = ["lxml"]
 
 [[package]]
+name = "mypy-boto3-s3"
+version = "1.35.2"
+description = "Type annotations for boto3.S3 1.35.2 service generated with mypy-boto3-builder 7.26.0"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "mypy_boto3_s3-1.35.2-py3-none-any.whl", hash = "sha256:f7300b559dee5435872625448becf159abe36b19cd7006dd78e0d51610312183"},
+    {file = "mypy_boto3_s3-1.35.2.tar.gz", hash = "sha256:74d8f3492eeff768ff6f69ac6d40bf68b40aa6e54ebe10a8d098fc3d24a54abf"},
+]
+
+[package.dependencies]
+typing-extensions = {version = ">=4.1.0", markers = "python_version < \"3.12\""}
+
+[[package]]
+name = "mypy-boto3-ses"
+version = "1.35.3"
+description = "Type annotations for boto3.SES 1.35.3 service generated with mypy-boto3-builder 7.26.1"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "mypy_boto3_ses-1.35.3-py3-none-any.whl", hash = "sha256:3af5bb82f2ec66221039c61d303baad9699258765556d8ebde3cfa1cd97154d8"},
+    {file = "mypy_boto3_ses-1.35.3.tar.gz", hash = "sha256:f93c88f9f7d737433d1d5580de241f8374ffc45e3dc2c958171f4c4f11c27d8c"},
+]
+
+[package.dependencies]
+typing-extensions = {version = ">=4.1.0", markers = "python_version < \"3.12\""}
+
+[[package]]
+name = "mypy-boto3-sesv2"
+version = "1.35.0"
+description = "Type annotations for boto3.SESV2 1.35.0 service generated with mypy-boto3-builder 7.26.0"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "mypy_boto3_sesv2-1.35.0-py3-none-any.whl", hash = "sha256:6c0e44c1521b6f505edee9b416a2b78b3c2cfa5f69bab34bec71f15758a3e39a"},
+    {file = "mypy_boto3_sesv2-1.35.0.tar.gz", hash = "sha256:6caad4ec7b9f69f534125b74e532d9acfc9cb3793110774970aa7a8b0581ede9"},
+]
+
+[package.dependencies]
+typing-extensions = {version = ">=4.1.0", markers = "python_version < \"3.12\""}
+
+[[package]]
 name = "mypy-extensions"
 version = "1.0.0"
 description = "Type system extensions for programs checked with the mypy type checker."
@@ -1844,6 +2314,17 @@ files = [
 ]
 
 [[package]]
+name = "types-awscrt"
+version = "0.21.4"
+description = "Type annotations and code completion for awscrt"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "types_awscrt-0.21.4-py3-none-any.whl", hash = "sha256:47f002cab99e25c10aee873d0f6d906a7144d58373b6ba68629993ed2d64f65b"},
+    {file = "types_awscrt-0.21.4.tar.gz", hash = "sha256:c2e58067a88818cb2aa2bdd39032aa41ce4b2637cef703edad477424f72530ee"},
+]
+
+[[package]]
 name = "types-requests"
 version = "2.32.0.20240712"
 description = "Typing stubs for requests"
@@ -1856,6 +2337,17 @@ files = [
 
 [package.dependencies]
 urllib3 = ">=2"
+
+[[package]]
+name = "types-s3transfer"
+version = "0.10.2"
+description = "Type annotations and code completion for s3transfer"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "types_s3transfer-0.10.2-py3-none-any.whl", hash = "sha256:7a3fec8cd632e2b5efb665a355ef93c2a87fdd5a45b74a949f95a9e628a86356"},
+    {file = "types_s3transfer-0.10.2.tar.gz", hash = "sha256:60167a3bfb5c536ec6cdb5818f7f9a28edca9dc3e0b5ff85ae374526fc5e576e"},
+]
 
 [[package]]
 name = "typing-extensions"
@@ -1938,4 +2430,4 @@ brotli = ["brotli"]
 [metadata]
 lock-version = "2.0"
 python-versions = "~3.11"
-content-hash = "171a7e88171bbc4ed345071074b1006cd76623bf35cae5c06e23356a30466914"
+content-hash = "4b10b9e1e5c07fb2c17ab7f9da08a274505e7eb1d5710827103928a48807f89d"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ whitenoise = {extras = ["brotli"], version = "^6.7.0"}
 optional = true
 
 [tool.poetry.group.dev.dependencies]
+boto3-stubs = {extras = ["s3", "ses", "sesv2"], version = "^1.35.13.post1"}
 django-debug-toolbar = "^4.4.6"
 mixer = "^7.2.2"
 mypy = "^1.11.2"

--- a/src/apps/tasks.py
+++ b/src/apps/tasks.py
@@ -29,8 +29,10 @@ def send_reservation_term_reminder(due_in_days: int = 2) -> dict[str, int]:
             template_name="MemberReservationReminder",
         )
         messages.append(message)
-
-    emails_sent = Mailer.send_mass_templated_email(messages)
+    emails_sent = Mailer.send_bulk_templated_email(
+        messages,
+        template="MemberReservationReminder",
+    )
     return {
         "sent": emails_sent,
         "messages_amount": len(messages),

--- a/src/apps/tasks.py
+++ b/src/apps/tasks.py
@@ -18,20 +18,20 @@ def send_reservation_term_reminder(due_in_days: int = 2) -> dict[str, int]:
     messages = []
     reservations_url = urljoin(env("PRODUCTION_URL"), "account/reservations/")
     for reservation in reservations:
-        member = reservation.member
-        body = f"""
-            Hi {member.name}!<br />
-            Your book '{reservation.book.title}' reservation is due on {reservation.term}.<br />
-            Please return it on time or extend it. <br />
-            Otherwise, you will be charged a fine. <br />
-            Check all your reservations <a href='{reservations_url}' target='_blank'>here</a>
-        """
-        messages.append(
-            Message(
-                subject=f"Reservation term is ending in {due_in_days} days",
-                body=body,
-            )
+        message: Message = Message(
+            template_data={
+                "due_in_days": due_in_days,
+                "member_name": reservation.member.name,
+                "book_title": reservation.book.title,
+                "reservation_term": str(reservation.term),
+                "reservations_url": reservations_url,
+            },
+            template_name="MemberReservationReminder",
         )
+        messages.append(message)
 
-    emails_sent = Mailer.send_mass_mail(messages, fail_silently=True)
-    return {"sent": emails_sent}
+    emails_sent = Mailer.send_mass_templated_email(messages)
+    return {
+        "sent": emails_sent,
+        "messages_amount": len(messages),
+    }

--- a/src/core/conf/logging.py
+++ b/src/core/conf/logging.py
@@ -1,0 +1,16 @@
+import os
+
+LOGGING = {
+    "version": 1,
+    "disable_existing_loggers": False,
+    "handlers": {
+        "console": {
+            "class": "logging.StreamHandler",
+        },
+    },
+    "root": {
+        "handlers": ["console"],
+        "level": os.getenv("DJANGO_LOG_LEVEL", "INFO"),
+        "propagate": False,
+    },
+}

--- a/src/core/settings.py
+++ b/src/core/settings.py
@@ -24,6 +24,7 @@ include(
     "conf/storages.py",
     "conf/sentry.py",
     "conf/mailing.py",
+    "conf/logging.py",
 )
 
 if DEBUG:

--- a/src/core/templates/email/admin_member_registration_request_received.json
+++ b/src/core/templates/email/admin_member_registration_request_received.json
@@ -1,0 +1,8 @@
+{
+    "Template": {
+        "TemplateName": "AdminMemberRegistrationRequestReceived",
+        "SubjectPart": "Registration request received",
+        "HtmlPart": "Hi admin! <br />New member registration request received. Check <a href='{{member_admin_url}}' target='_blank'>here</a>",
+        "TextPart": "Hi admin!\r\nNew member registration request received. Check <a href='{{member_admin_url}}' target='_blank'>here</a>"
+    }
+}

--- a/src/core/templates/email/admin_order_created.json
+++ b/src/core/templates/email/admin_order_created.json
@@ -1,0 +1,8 @@
+{
+    "Template": {
+        "TemplateName": "AdminOrderCreated",
+        "SubjectPart": "Book order created",
+        "HtmlPart": "Hi admin!<br />Please process new book order <a href='{{order_url}}' target='_blank'>here</a>",
+        "TextPart": "Hi admin!\r\nPlease process new book order <a href='{{order_url}}' target='_blank'>here</a>"
+    }
+}

--- a/src/core/templates/email/admin_reservation_extension_requested.json
+++ b/src/core/templates/email/admin_reservation_extension_requested.json
@@ -1,0 +1,8 @@
+{
+    "Template": {
+        "TemplateName": "AdminReservationExtensionRequested",
+        "SubjectPart": "New reservation extension request",
+        "HtmlPart": "Hi admin! <br />New reservation extension request received. <br /> Please, process it <a href='{{extension_admin_url}}' target='_blank'>here</a>",
+        "TextPart": "Hi admin! \r\nNew reservation extension request received. \r\n Please, process it <a href='{{extension_admin_url}}' target='_blank'>here</a>"
+    }
+}

--- a/src/core/templates/email/member_password_reset_link.json
+++ b/src/core/templates/email/member_password_reset_link.json
@@ -1,0 +1,8 @@
+{
+    "Template": {
+        "TemplateName": "MemberPasswordResetLink",
+        "SubjectPart": "Password reset request",
+        "HtmlPart": "Hi {{member_name}}!<br />You requested password reset recently.<br />Please visit that link below to set a new password for your account:<br /><a href='{{password_reset_url}}' target='_blank'>Reset password</a><br />Link expires in 1 hour.",
+        "TextPart": "Hi {{member_name}}!\r\nYou requested password reset recently.\r\nPlease visit that link below to set a new password for your account:\r\n<a href='{{password_reset_url}}' target='_blank'>Reset password</a>\r\nLink expires in 1 hour."
+    }
+}

--- a/src/core/templates/email/member_registration_notification.json
+++ b/src/core/templates/email/member_registration_notification.json
@@ -1,0 +1,8 @@
+{
+    "Template": {
+        "TemplateName": "MemberRegistrationNotification",
+        "SubjectPart": "Thanks! Your registration request received",
+        "HtmlPart": "Hi {{member_name}}!<br />Your registration code: {{member_registration_code}}.<br />Please arrive to library to complete registration.<br />Don't forget to bring your ID card.",
+        "TextPart": "Hi {{member_name}}!\r\nYour registration code: {{member_registration_code}}.\r\nPlease arrive to library to complete registration.\r\nDon't forget to bring your ID card."
+    }
+}

--- a/src/core/templates/email/member_reservation_confirmed.json
+++ b/src/core/templates/email/member_reservation_confirmed.json
@@ -1,0 +1,8 @@
+{
+    "Template": {
+        "TemplateName": "MemberReservationConfirmed",
+        "SubjectPart": "Book is ready to be issued",
+        "HtmlPart": "Hi {{ member_name }}!<br />\"{{ book_title }}\" book is ready to be picked up. <br /> Your Reservation ID: {{ reservations_id }} <br />View all your reservations <a href='{{ reservations_url }}' target='_blank'>here</a>",
+        "TextPart": "Hi {{ member_name }}!\r\n\"{{ book_title }}\" book is ready to be picked up. \r\n Your Reservation ID: {{ reservations_id }} \r\nView all your reservations <a href='{{ reservations_url }}' target='_blank'>here</a>"
+    }
+}

--- a/src/core/templates/email/member_reservation_extension_approved.json
+++ b/src/core/templates/email/member_reservation_extension_approved.json
@@ -1,0 +1,8 @@
+{
+    "Template": {
+        "TemplateName": "MemberReservationExtensionApproved",
+        "SubjectPart": "Your \"{{ book_title }}\" reservation was approved.",
+        "HtmlPart": "Hi {{member_name}}! <br />Your \"{{book_title}}\" reservation is now extended till {{reservation_term}}. <br />View all your reservations <a href='{{reservations_url}}' target='_blank'>here</a>",
+        "TextPart": "Hi {{member_name}}! \r\nYour \"{{book_title}}\" reservation is now extended till {{reservation_term}}. \r\nView all your reservations <a href='{{reservations_url}}' target='_blank'>here</a>"
+    }
+}

--- a/src/core/templates/email/member_reservation_reminder.json
+++ b/src/core/templates/email/member_reservation_reminder.json
@@ -1,0 +1,8 @@
+{
+    "Template": {
+        "TemplateName": "MemberReservationReminder",
+        "SubjectPart": "Reservation term is ending in {{due_in_days}} days",
+        "HtmlPart": "Hi {{member_name}}!<br />Your book '{{book_title}}' reservation is due on {{reservation_term}}.<br />Please return it on time or extend it. <br />Otherwise, you will be charged a fine. <br />Check all your reservations <a href='{{reservations_url}}' target='_blank'>here</a>",
+        "TextPart": "Hi {{member_name}}!\r\nYour book '{{book_title}}' reservation is due on {{reservation_term}}.\r\nPlease return it on time or extend it. \r\nOtherwise, you will be charged a fine. \r\nCheck all your reservations <a href='{{reservations_url}}' target='_blank'>here</a>"
+    }
+}

--- a/src/core/utils/mailer.py
+++ b/src/core/utils/mailer.py
@@ -1,14 +1,19 @@
-from typing import NamedTuple
+import json
+import logging
+from typing import Any, NamedTuple
 
 import sentry_sdk
 from django.conf import settings
 from django.core.mail import EmailMessage, get_connection
 from django_ses import SESBackend
+from mypy_boto3_ses import SESClient
+
+logger = logging.getLogger()
 
 
 class Message(NamedTuple):
-    subject: str
-    body: str
+    template_name: str
+    template_data: dict[str, Any] = {}
     from_email: str = settings.AWS_SES_FROM_EMAIL
     to: list[str] | tuple[str] = (settings.AWS_SES_FROM_EMAIL,)
     reply_to: list[str] | tuple[str] = ("noreply@django-libraryms.fly.dev",)
@@ -19,61 +24,46 @@ class HtmlEmailMessage(EmailMessage):
 
 
 class Mailer:
-    def __init__(self, message: Message):
-        self.email = HtmlEmailMessage(
-            subject=message.subject,
-            body=Mailer.compact_body(message.body),
-            from_email=message.from_email,
-            to=message.to,
-            reply_to=message.reply_to,
-        )
-
-    def send(self) -> int:
-        """
-        The return value will be the number of successfully delivered messages
-        (which can be 0 or 1 since it can only send one message).
-        """
-        return self.email.send()
-
     @classmethod
-    def compact_body(cls, body: str) -> str:
-        "Strips whitespaces before/after and within each body line"
-
-        return "".join([line.strip() for line in body.split("\n")])
-
-    @classmethod
-    def send_mass_mail(cls, messages: list[Message], fail_silently: bool = False) -> int:
+    def send_templated_email(cls, message: Message, connection: SESBackend = None) -> int:
         """
-        Extends Django's send_mass_mail() to support sending mass emails as html by default.
+        Sends templated email using Amazon SES or prints to console if not using SES.
         """
 
-        connection: SESBackend = get_connection(fail_silently=fail_silently)
-        html_messages = [
-            HtmlEmailMessage(
-                subject=message.subject,
-                body=cls.compact_body(message.body),
-                from_email=message.from_email,
-                to=message.to,
-                connection=connection,
+        backend: SESBackend = connection or get_connection()
+        if not hasattr(backend, "connection"):
+            logger.info(f"Sending '{message.template_name}' email to {message.to}")
+            return 1
+
+        num_sent = 0
+        new_conn_created = backend.open()
+        try:
+            ses_client: SESClient = backend.connection
+            ses_client.send_templated_email(
+                Source=message.from_email,
+                Destination={
+                    "ToAddresses": message.to,
+                },
+                ReplyToAddresses=message.reply_to,
+                Template=message.template_name,
+                TemplateData=json.dumps(message.template_data),
             )
-            for message in messages
-        ]
-        emails_sent = connection.send_messages(html_messages)
-
-        if fail_silently:
-            failed_delivery = [m for m in html_messages if m.extra_headers.get("status", 200) != 200]
-            for failed_email in failed_delivery:
-                sentry_sdk.capture_message(
-                    "Failed to send reminder email",
-                    extra={
-                        "status": failed_email.extra_headers["status"],
-                        "message": failed_email.extra_headers["message"],
-                        "reason": failed_email.extra_headers["reason"],
-                        "error_message": failed_email.extra_headers["error_message"],
-                        "error_code": failed_email.extra_headers["error_code"],
-                    },
-                )
+            num_sent += 1
+            logger.info(f"Sent '{message.template_name}' email to {message.to}")
+        except Exception as exc:
             # TODO: add failure emailure deliveries for retry in separate periodict task
             # .e.g by saving all context in FailedEmail model
+            sentry_sdk.capture_exception(exc)
 
-        return emails_sent
+        if new_conn_created:
+            backend.close()
+
+        return num_sent
+
+    @classmethod
+    def send_mass_templated_email(cls, messages: list[Message]) -> int:
+        connection = get_connection()
+        num_sent = 0
+        for message in messages:
+            num_sent += cls.send_templated_email(message, connection)
+        return num_sent

--- a/tests/apps/books/test_send_reservation_term_reminder.py
+++ b/tests/apps/books/test_send_reservation_term_reminder.py
@@ -14,9 +14,12 @@ pytestmark = [
 ]
 
 
-@pytest.fixture
-def mock_send_mass_templated_email(mocker):
-    return mocker.patch("apps.tasks.Mailer.send_mass_templated_email", side_effect=lambda messages: len(messages))
+@pytest.fixture(autouse=True)
+def mock_send_bulk_templated_email(mocker):
+    def mock_send_bulk_templated_email(messages, template):
+        return len(messages)
+
+    return mocker.patch("apps.tasks.Mailer.send_bulk_templated_email", side_effect=mock_send_bulk_templated_email)
 
 
 @pytest.fixture
@@ -57,14 +60,17 @@ def test_send_2_reminders(_create_book_reservations):
     assert result["sent"] == 2
 
 
-def test_templated_message_properties(_create_book_reservations, mock_send_mass_templated_email):
+def test_send_bulk_templated_email_args(_create_book_reservations, mock_send_bulk_templated_email):
     _create_book_reservations(due_in_days=[10, 2, 2])
 
     result = send_reservation_term_reminder.delay(due_in_days=2).get()
 
-    messages = mock_send_mass_templated_email.call_args[0][0]
+    messages = mock_send_bulk_templated_email.call_args[0][0]
+    mock_send_bulk_templated_email.call_args[1] == {"template": "MemberReservationReminder"}
     assert result == {"sent": 2, "messages_amount": 2}
-    assert mock_send_mass_templated_email.call_count == 1
-    assert messages[0].template_name == "MemberReservationReminder"
+    assert mock_send_bulk_templated_email.call_count == 1
     assert messages[0].template_data["reservations_url"] == "https://example.com/account/reservations/"
     assert messages[0].template_data["due_in_days"] == 2
+    assert messages[0].template_data["member_name"]
+    assert messages[0].template_data["book_title"]
+    assert messages[0].template_data["reservation_term"]

--- a/tests/apps/users/test_send_extension_request_received_email.py
+++ b/tests/apps/users/test_send_extension_request_received_email.py
@@ -12,8 +12,8 @@ def test_success(mock_mailer):
     result = send_extension_request_received_email.delay(extension_id).get()
 
     assert result["sent"]
-    message: Message = mock_mailer.call_args[0][0]
-    assert message.subject == "New reservation extension request"
-    assert "Hi admin!" in message.body
-    assert "New reservation extension request received" in message.body
-    assert "https://example.com/admin/books/reservationextension/1/change/" in message.body
+    message: Message = mock_mailer.send_templated_email.call_args[0][0]
+    assert message.template_name == "AdminReservationExtensionRequested"
+    assert message.template_data == {
+        "extension_admin_url": "https://example.com/admin/books/reservationextension/1/change/",
+    }

--- a/tests/apps/users/test_send_member_registration_request_received.py
+++ b/tests/apps/users/test_send_member_registration_request_received.py
@@ -12,8 +12,8 @@ def test_success(mock_mailer):
     result = send_member_registration_request_received.delay(member_id).get()
 
     assert result["sent"]
-    message: Message = mock_mailer.call_args[0][0]
-    assert message.subject == "Registration request received"
-    assert "Hi admin!" in message.body
-    assert "New member registration request received" in message.body
-    assert "https://example.com/admin/users/member/1/change/" in message.body
+    message: Message = mock_mailer.send_templated_email.call_args[0][0]
+    assert message.template_name == "AdminMemberRegistrationRequestReceived"
+    assert message.template_data == {
+        "member_admin_url": "https://example.com/admin/users/member/1/change/",
+    }

--- a/tests/apps/users/test_send_registration_notification_to_member.py
+++ b/tests/apps/users/test_send_registration_notification_to_member.py
@@ -21,19 +21,19 @@ def test_send_success_with_first_name_in_greeting(mock_mailer):
 
     result = send_registration_notification_to_member.delay(member.id).get()
 
+    message: Message = mock_mailer.send_templated_email.call_args[0][0]
     assert result["sent"]
-    message: Message = mock_mailer.call_args[0][0]
-    assert message.subject == "Thanks! Your registration request received"
-    assert f"Hi {member.first_name}!" in message.body
-    assert f"Your registration code: {member.registration_code}." in message.body
-    assert "Please arrive to library to complete registration" in message.body
-    assert "Don't forget to bring your ID card." in message.body
+    assert message.template_data == {
+        "member_name": member.name,
+        "member_registration_code": member.registration_code,
+    }
+    assert message.template_name == "MemberRegistrationNotification"
 
 
-def test_send_success_with_username_in_greeting(mock_mailer):
+def test_template_data_includes_username(mock_mailer):
     member: Member = mixer.blend(Member, first_name="")
 
     send_registration_notification_to_member.delay(member.id).get()
 
-    message: Message = mock_mailer.call_args[0][0]
-    assert f"Hi {member.username}!" in message.body
+    message: Message = mock_mailer.send_templated_email.call_args[0][0]
+    assert message.template_data["member_name"] == member.username

--- a/tests/apps/users/test_send_reservation_extension_approved_email.py
+++ b/tests/apps/users/test_send_reservation_extension_approved_email.py
@@ -20,7 +20,11 @@ def test_success(mock_mailer, member_reservation):
     member: Member = member_reservation.member
 
     assert result["sent"]
-    message: Message = mock_mailer.call_args[0][0]
-    assert message.subject == f'Your "{member_reservation.book.title}" reservation was approved.'
-    assert f"Hi {member.first_name}!" in message.body
-    assert f'Your "{member_reservation.book.title}" reservation is now extended till {member_reservation.term}. <br />' in message.body
+    message: Message = mock_mailer.send_templated_email.call_args[0][0]
+    assert message.template_name == "MemberReservationExtensionApproved"
+    assert message.template_data == {
+        "member_name": member.name,
+        "book_title": member_reservation.book.title,
+        "reservation_term": str(member_reservation.term),
+        "reservations_url": "https://example.com/account/reservations/",
+    }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,5 +23,5 @@ def _use_simple_password_hasher(settings):
 @pytest.fixture(autouse=True)
 def mock_mailer(mocker):
     mocked = mocker.patch("core.tasks.Mailer")
-    mocked.return_value.send.return_value = 1
+    mocked.send_templated_email.return_value = 1
     return mocked

--- a/tests/core/tasks/test_send_order_created_email.py
+++ b/tests/core/tasks/test_send_order_created_email.py
@@ -8,8 +8,8 @@ def test_send_order_created_email(mock_mailer):
     result = send_order_created_email.delay(order_id).get()
 
     assert result["sent"] == 1
-    message: Message = mock_mailer.call_args[0][0]
-    assert message.subject == "Book order created"
-    assert "Hi admin!" in message.body
-    assert "Please process new book order" in message.body
-    assert "https://example.com/admin/books/order/1/change/" in message.body
+    message: Message = mock_mailer.send_templated_email.call_args[0][0]
+    assert message.template_name == "AdminOrderCreated"
+    assert message.template_data == {
+        "order_url": "https://example.com/admin/books/order/1/change/",
+    }

--- a/tests/core/tasks/test_send_password_reset_link_to_member.py
+++ b/tests/core/tasks/test_send_password_reset_link_to_member.py
@@ -27,10 +27,10 @@ def test_ensures_valid_reset_token_before_sent(member: Member):
 def test_email_sent(member_with_reset_token, mock_mailer):
     result = send_password_reset_link_to_member.delay(member_with_reset_token.id).get()
 
-    message: Message = mock_mailer.call_args[0][0]
-    assert message.subject == "Password reset request"
-    assert f"Hi {member_with_reset_token.first_name}!" in message.body
-    assert "You requested password reset recently." in message.body
-    assert f"https://example.com/reset-password/{member_with_reset_token.password_reset_token}" in message.body
-    assert "Link expires in 1 hour" in message.body
     assert result["sent"] == 1
+    message: Message = mock_mailer.send_templated_email.call_args[0][0]
+    assert message.template_name == "MemberPasswordResetLink"
+    assert message.template_data == {
+        "member_name": member_with_reset_token.name,
+        "password_reset_url": f"https://example.com/reset-password/{member_with_reset_token.password_reset_token}",
+    }

--- a/tests/core/tasks/test_send_reservation_confirmed_email.py
+++ b/tests/core/tasks/test_send_reservation_confirmed_email.py
@@ -21,12 +21,14 @@ def test_send_reservation_confirmed_email_success(mock_mailer, book_order):
 
     assert result["sent"] == 1
 
-    message: Message = mock_mailer.call_args[0][0]
-    assert message.subject == "Book is ready to be picked up"
-    assert f"Hi {book_order.member.first_name}!" in message.body
-    assert f"{book_order.book.title}" in message.body
-    assert f"Your Reservation ID: {book_order.reservation.id}" in message.body
-    assert "https://example.com/account/reservations/" in message.body
+    message: Message = mock_mailer.send_templated_email.call_args[0][0]
+    assert message.template_name == "MemberReservationConfirmed"
+    assert message.template_data == {
+        "member_name": book_order.member.name,
+        "book_title": book_order.book.title,
+        "reservations_id": book_order.reservation.id,
+        "reservations_url": "https://example.com/account/reservations/",
+    }
 
 
 def test_send_reservation_confirmed_email_success_username_used_as_fallback(mock_mailer, book_order):
@@ -35,14 +37,5 @@ def test_send_reservation_confirmed_email_success_username_used_as_fallback(mock
 
     send_reservation_confirmed_email.delay(book_order.id, book_order.reservation.id).get()
 
-    message: Message = mock_mailer.call_args[0][0]
-    assert f"Hi {book_order.member.username}!" in message.body
-
-
-def test_member_not_marked_as_notified_in_case_of_exception(mock_mailer, book_order):
-    mock_mailer.return_value.send.side_effect = Exception("Could not send email")
-
-    with pytest.raises(Exception):
-        send_reservation_confirmed_email.delay(book_order.id, book_order.reservation.id).get()
-
-    book_order.refresh_from_db()
+    message: Message = mock_mailer.send_templated_email.call_args[0][0]
+    assert message.template_data["member_name"] == book_order.member.username

--- a/tests/core/test_mailer.py
+++ b/tests/core/test_mailer.py
@@ -1,59 +1,93 @@
-import pytest
-from django.core.mail import EmailMessage
+import json
 
-from src.core.utils.mailer import HtmlEmailMessage, Mailer, Message
+import pytest
+
+from src.core.utils.mailer import Mailer, Message
 
 
 @pytest.fixture
-def sample_message():
-    return Message(subject="Test Subject", body="Test Body", from_email="from@example.com", to=["to@example.com"], reply_to=["reply@example.com"])
+def sample_message() -> Message:
+    return Message(
+        template_name="SampleTemplate",
+        template_data={"sample": "data"},
+        from_email="from@example.com",
+        to=["to@example.com"],
+        reply_to=["reply@example.com"],
+    )
 
 
-def test_mailer_init(sample_message):
-    mailer = Mailer(sample_message)
-    assert isinstance(mailer.email, HtmlEmailMessage)
-
-    assert mailer.email.subject == "Test Subject"
-    assert mailer.email.body == "Test Body"
-    assert mailer.email.from_email == "from@example.com"
-    assert mailer.email.to == ["to@example.com"]
-    assert mailer.email.reply_to == ["reply@example.com"]
-
-
-def test_mailer_init_compact_body():
-    message = Message(subject="Test Subject", body="  Line 1  \n  Line 2  \n  Line 3  ", from_email="from@example.com", to=["to@example.com"])
-    mailer = Mailer(message)
-
-    assert mailer.email.body == "Line 1Line 2Line 3"
+@pytest.fixture
+def mock_backend(mocker):
+    backend = mocker.patch("src.core.utils.mailer.get_connection")
+    backend.connection = backend.return_value.connection
+    backend.send_templated_email = backend.connection.send_templated_email
+    backend.open = backend.return_value.open
+    backend.close = backend.return_value.close
+    return backend
 
 
-def test_mailer_compact_body():
-    input_body = """
-    This is a test email body.<br/>
-    It has multiple lines.
-        Some lines have extra indentation.
-
-    There are also empty lines.
-    """
-    expected_output = "This is a test email body.<br/>It has multiple lines.Some lines have extra indentation.There are also empty lines."
-
-    result = Mailer.compact_body(input_body)
-    assert result == expected_output
+@pytest.fixture
+def mock_sentry_capture_exception(mocker):
+    return mocker.patch("src.core.utils.mailer.sentry_sdk.capture_exception")
 
 
-def test_mailer_send(sample_message, mocker):
-    mailer = Mailer(sample_message)
-    mock_send = mocker.patch.object(EmailMessage, "send", return_value=1)
-    result = mailer.send()
+@pytest.fixture
+def mock_logger(mocker):
+    return mocker.patch("src.core.utils.mailer.logger")
+
+
+def test_send_templated_email(sample_message: Message, mock_backend):
+    result = Mailer.send_templated_email(sample_message)
 
     assert result == 1
-    mock_send.assert_called_once()
+    mock_backend.assert_called_once()
 
 
-def test_mailer_send_failure(sample_message, mocker):
-    mailer = Mailer(sample_message)
-    mock_send = mocker.patch.object(EmailMessage, "send", return_value=0)
-    result = mailer.send()
+def test_send_mass_templated_email(sample_message: Message, mock_backend):
+    result = Mailer.send_mass_templated_email([sample_message, sample_message])
+
+    assert result == 2
+    mock_backend.assert_called_once()
+
+
+def test_print_to_console_in_dev_envs(sample_message: Message, mock_backend, mock_logger):
+    # console/dummy backends are not expected to have backend connection attribute
+    delattr(mock_backend.return_value, "connection")
+
+    Mailer.send_templated_email(sample_message)
+
+    mock_logger.info.assert_called_once_with(f"Sending '{sample_message.template_name}' email to {sample_message.to}")
+
+
+def test_send_templated_email_with_connection(sample_message: Message, mock_backend, mock_logger):
+    result = Mailer.send_templated_email(sample_message)
+
+    assert result == 1
+    mock_backend.assert_called_once()
+    mock_backend.open.assert_called_once()
+    mock_backend.close.assert_called_once()
+    mock_backend.send_templated_email.assert_called_with(
+        Source=sample_message.from_email,
+        Destination={"ToAddresses": sample_message.to},
+        ReplyToAddresses=sample_message.reply_to,
+        Template=sample_message.template_name,
+        TemplateData=json.dumps(sample_message.template_data),
+    )
+    mock_logger.info.assert_called_once_with(f"Sent '{sample_message.template_name}' email to {sample_message.to}")
+
+
+def test_mass_templated_email(sample_message: Message, mock_backend):
+    result = Mailer.send_mass_templated_email([sample_message, sample_message])
+
+    mock_backend.assert_called_once()
+    assert result == 2
+    assert mock_backend.send_templated_email.call_count == 2
+
+
+def test_exception_captured(sample_message: Message, mock_backend, mock_sentry_capture_exception):
+    exception = Exception("Could not deliver email")
+    mock_backend.send_templated_email.side_effect = exception
+    result = Mailer.send_templated_email(sample_message)
 
     assert result == 0
-    mock_send.assert_called_once()
+    mock_sentry_capture_exception.assert_called_once_with(exception)

--- a/tests/core/test_mailer.py
+++ b/tests/core/test_mailer.py
@@ -21,6 +21,7 @@ def mock_backend(mocker):
     backend = mocker.patch("src.core.utils.mailer.get_connection")
     backend.connection = backend.return_value.connection
     backend.send_templated_email = backend.connection.send_templated_email
+    backend.send_bulk_templated_email = backend.connection.send_bulk_templated_email
     backend.open = backend.return_value.open
     backend.close = backend.return_value.close
     return backend
@@ -32,6 +33,11 @@ def mock_sentry_capture_exception(mocker):
 
 
 @pytest.fixture
+def mock_sentry_capture_message(mocker):
+    return mocker.patch("src.core.utils.mailer.sentry_sdk.capture_message")
+
+
+@pytest.fixture
 def mock_logger(mocker):
     return mocker.patch("src.core.utils.mailer.logger")
 
@@ -40,13 +46,6 @@ def test_send_templated_email(sample_message: Message, mock_backend):
     result = Mailer.send_templated_email(sample_message)
 
     assert result == 1
-    mock_backend.assert_called_once()
-
-
-def test_send_mass_templated_email(sample_message: Message, mock_backend):
-    result = Mailer.send_mass_templated_email([sample_message, sample_message])
-
-    assert result == 2
     mock_backend.assert_called_once()
 
 
@@ -76,14 +75,6 @@ def test_send_templated_email_with_connection(sample_message: Message, mock_back
     mock_logger.info.assert_called_once_with(f"Sent '{sample_message.template_name}' email to {sample_message.to}")
 
 
-def test_mass_templated_email(sample_message: Message, mock_backend):
-    result = Mailer.send_mass_templated_email([sample_message, sample_message])
-
-    mock_backend.assert_called_once()
-    assert result == 2
-    assert mock_backend.send_templated_email.call_count == 2
-
-
 def test_exception_captured(sample_message: Message, mock_backend, mock_sentry_capture_exception):
     exception = Exception("Could not deliver email")
     mock_backend.send_templated_email.side_effect = exception
@@ -91,3 +82,59 @@ def test_exception_captured(sample_message: Message, mock_backend, mock_sentry_c
 
     assert result == 0
     mock_sentry_capture_exception.assert_called_once_with(exception)
+
+
+def test_send_bulk_templated_email(sample_message, mock_backend):
+    messages = [sample_message, sample_message]
+    mock_backend.send_bulk_templated_email.return_value = {
+        "Status": [
+            {
+                "Status": "Success",
+                "MessageId": "123",
+            }
+            for _ in messages
+        ]
+    }
+    num_sent = Mailer.send_bulk_templated_email(messages, template="SampleTemplate")
+
+    assert num_sent == 2
+    mock_backend.assert_called_once()
+    mock_backend.open.assert_called_once()
+    mock_backend.send_bulk_templated_email.assert_called_once()
+    mock_backend.close.assert_called_once()
+
+
+def test_send_bulk_templated_email_exception_captured(sample_message, mock_backend, mock_sentry_capture_exception):
+    messages = [sample_message, sample_message]
+    exception = Exception("Could not deliver email")
+    mock_backend.send_bulk_templated_email.side_effect = exception
+
+    Mailer.send_bulk_templated_email(messages, template="SampleTemplate")
+    mock_sentry_capture_exception.assert_called_once_with(exception)
+
+
+def test_send_bulk_templated_email_one_failure(sample_message, mock_backend, mock_sentry_capture_message):
+    messages = [sample_message, sample_message]
+    failed_message = {"Status": "Failed", "MessageId": "321", "Error": "Error message"}
+    mock_backend.send_bulk_templated_email.return_value = {
+        "Status": [
+            {"Status": "Success", "MessageId": "123"},
+            failed_message,
+        ]
+    }
+    num_sent = Mailer.send_bulk_templated_email(messages, template="SampleTemplate")
+
+    assert num_sent == 1
+    mock_sentry_capture_message.assert_called_once_with(
+        f"Failed to deliver email. Status: {failed_message['Status']}, Error: {failed_message['Error']}",
+        level="error",
+    )
+
+
+def test_bulk_send_print_to_console_in_dev_envs(sample_message: Message, mock_backend, mock_logger):
+    # console/dummy backends are not expected to have backend connection attribute
+    delattr(mock_backend.return_value, "connection")
+    messages = [sample_message, sample_message]
+    Mailer.send_bulk_templated_email(messages, template="SampleTemplate")
+
+    mock_logger.info.assert_called_once_with(f"Sending 'SampleTemplate' email to [{[', '.join(message.to) for message in messages]}]")


### PR DESCRIPTION
- Moves hardcoded email HTML to AWS SES templates 
- Stores SES templates as JSON in the repo while the SES sandbox account is still active.(afterward all HTML can be put directly in the email template editor)
- `django_ses` package is still leveraged to create boto3 ses sessions, and opening/closing connections.
- adds  s3, ses, sesv2 boto3 type annotations
- leverages [send_templated_email](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/ses/client/send_templated_email.html) for single email sending  and [send_bulk_templated_email](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/ses/client/send_bulk_templated_email.html#) for bulk sending accordingly
- adds simple root logger for info logs.